### PR TITLE
docs: add 8 official DevOps/SRE MCP servers and polish README

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/new-entry.yml
+++ b/.github/ISSUE_TEMPLATE/new-entry.yml
@@ -1,0 +1,64 @@
+name: Suggest a new catalog entry
+description: Propose an official MCP server, agent skill, or agent toolkit for DevOps, Cloud, SRE, or Platform Engineering.
+title: "New entry: "
+labels:
+  - new-entry
+body:
+  - type: input
+    id: repo-url
+    attributes:
+      label: Repo or docs URL
+      description: Must be public and reachable.
+      placeholder: https://github.com/org/repo
+    validations:
+      required: true
+
+  - type: input
+    id: category
+    attributes:
+      label: Proposed category
+      description: One of the categories in the README, or a new one if none fit.
+      placeholder: official-sre-mcp-servers
+    validations:
+      required: true
+
+  - type: dropdown
+    id: action-level
+    attributes:
+      label: Action level
+      description: Can this tool only read data, propose changes, or write/mutate directly?
+      options:
+        - read-only
+        - proposal
+        - write-capable
+        - unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: operator-note
+    attributes:
+      label: Why should an infrastructure operator care?
+      description: The real DevOps/Cloud/SRE/platform-engineering use case. No hype-only entries.
+    validations:
+      required: true
+
+  - type: textarea
+    id: risk-notes
+    attributes:
+      label: What could go wrong?
+      description: Safety, approval gates, credential scope, or blast-radius notes.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Entry checklist (see CONTRIBUTING.md)
+      options:
+        - label: The repo URL is public and reachable.
+          required: true
+        - label: This is an official vendor/maintainer resource, not a hype-only or unmaintained fork.
+          required: true
+        - label: I disclosed if the project is commercial-only or has OSS-limited functionality.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- What entry, category, or docs change does this PR add or update? -->
+
+## Entry checklist (skip if this PR doesn't add/change a catalog entry)
+
+- [ ] The repo URL is public and reachable.
+- [ ] The entry has a specific category.
+- [ ] The `risk_notes` field explains what could go wrong.
+- [ ] The `operator_note` field explains why an infrastructure operator should care.
+- [ ] The `gemini_opportunity` field describes a concrete Gemini-compatible build or evaluation path.
+- [ ] Labels match the observed behavior, not marketing claims.
+- [ ] `data/repos.yaml` and `README.md` are both updated.
+
+## Validation
+
+```bash
+python scripts/validate_repos_yaml.py
+pytest -q
+python scripts/run_mock_eval_scenarios.py
+python scripts/audit_github_repos.py --workers 12 --fail-on-unreachable
+```
+
+- [ ] All of the above pass locally.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
 # Awesome Agentic DevOps
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![CI](https://github.com/DevOpsAIguru123/awesome-agentic-devops/actions/workflows/validate.yml/badge.svg)](https://github.com/DevOpsAIguru123/awesome-agentic-devops/actions/workflows/validate.yml)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+
 **Awesome Agentic DevOps** is a curated map for DevOps, Cloud, SRE, and Platform Engineering agents across Claude Code, Gemini ADK, OpenAI Agents SDK, and MCP.
 
 This repository evaluates which agents are safe, useful, and production-adjacent for infrastructure automation.
+
+## Contents
+
+- [Why this exists](#why-this-exists)
+- [Who it is for](#who-it-is-for)
+- [Safety-first disclaimer](#safety-first-disclaimer)
+- [Evaluation labels](#evaluation-labels)
+- [Categories](#categories)
+- [Top picks by use case](#top-picks-by-use-case)
+- [Curated catalog](#curated-catalog)
+- [How to contribute](#how-to-contribute)
 
 ## Why this exists
 
@@ -47,7 +62,8 @@ These agents may touch infrastructure. Prefer read-only or proposal mode first. 
 8. Official platform agent toolkits
 9. Official MCP SDKs, references, registries, and governance platforms
 10. Official diagramming and architecture MCP tools
-11. Community discovery and skill references
+11. Official data platform MCP servers
+12. Community discovery and skill references
 
 ## Top picks by use case
 
@@ -78,6 +94,8 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The list below is a r
 | [google/mcp](https://github.com/google/mcp) | 🟢 🔵 🛡️ 💎 ⚠️ | Official Google MCP repository listing managed and open-source MCP servers for Google and Google Cloud. |
 | [googleapis/gcloud-mcp](https://github.com/googleapis/gcloud-mcp) | 🟢 🔵 🛡️ 💎 ⚠️ | Official Google API repository for gcloud, observability, storage, and backup/disaster-recovery MCP servers. |
 | [GoogleCloudPlatform/cloud-run-mcp](https://github.com/GoogleCloudPlatform/cloud-run-mcp) | 🟢 🔵 🛡️ 💎 ⚠️ | Official Google Cloud Platform MCP server for deploying apps to Cloud Run. |
+| [cloudflare/mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare) | 🟢 🔵 🛡️ 💎 ⚠️ | Official Cloudflare MCP servers for account, Workers, and edge configuration workflows. |
+| [vercel/vercel-mcp-overview](https://github.com/vercel/vercel-mcp-overview) | 🟢 🔵 🛡️ 💎 ⚠️ | Official public overview of Vercel's hosted MCP server for project and deployment context. |
 
 ### Official DevOps MCP Servers
 
@@ -106,6 +124,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The list below is a r
 | --- | --- | --- |
 | [jenkinsci/mcp-server-plugin](https://github.com/jenkinsci/mcp-server-plugin) | 🟢 🔵 🛡️ 💎 ⚠️ | Official Jenkins plugin that enables Jenkins to act as an MCP server for LLM-powered clients. |
 | [argoproj-labs/mcp-for-argocd](https://github.com/argoproj-labs/mcp-for-argocd) | 🟡 🔵 🛡️ 💎 ⚠️ | Argo Project Labs MCP server implementation for Argo CD, filling the GitOps/CD gap in the catalog. |
+| [CircleCI-Public/mcp-server-circleci](https://github.com/CircleCI-Public/mcp-server-circleci) | 🟢 🔵 🛡️ 📊 💎 | Official CircleCI MCP server for build failure logs, pipeline status, flaky test detection, and usage analysis. |
 
 ### Official MCP SDKs, Reference Implementations, Registries, and Governance Platforms
 
@@ -130,6 +149,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The list below is a r
 | --- | --- | --- |
 | [hashicorp/terraform-mcp-server](https://github.com/hashicorp/terraform-mcp-server) | 🟢 🔵 🛡️ 📊 💎 ⚠️ | Official HashiCorp Terraform MCP server with registry, HCP Terraform, Terraform Enterprise, and OTel support. |
 | [Pulumi MCP Server](https://www.pulumi.com/docs/ai/mcp-server/) | 🟢 🔵 🛡️ 💎 ⚠️ | Official Pulumi hosted MCP server for Pulumi Cloud resources, registry lookup, policies, and Pulumi Neo workflows. |
+| [hashicorp/vault-mcp-server](https://github.com/hashicorp/vault-mcp-server) | 🟢 🔵 🛡️ 💎 ⚠️ | Official HashiCorp Vault MCP server (beta) for secrets and mount management alongside Terraform-driven IaC workflows. |
 
 ### Official SRE MCP Servers
 
@@ -141,6 +161,8 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The list below is a r
 | [Datadog MCP Server setup docs](https://docs.datadoghq.com/mcp_server/setup/?tab=chatgpt) | 🟢 🔵 🛡️ 📊 💎 | Official Datadog MCP setup documentation, including the ChatGPT setup path. |
 | [Splunk MCP Server](https://splunkbase.splunk.com/app/7931) | 🟢 🔵 🛡️ 📊 💎 | Splunkbase listing for the Splunk-supported MCP Server for Splunk Platform, Enterprise, and Cloud customers. |
 | [PagerDuty/pagerduty-mcp-server](https://github.com/PagerDuty/pagerduty-mcp-server) | 🟢 🔵 🛡️ 💎 ⚠️ | Official PagerDuty MCP server for incidents, services, schedules, event orchestrations, and embedded incident UIs. |
+| [newrelic/mcp-server](https://github.com/newrelic/mcp-server) | 🟢 🔵 🛡️ 📊 💎 | Official New Relic MCP server for APM, dashboard, and NRQL-based observability context. |
+| [elastic/mcp-server-elasticsearch](https://github.com/elastic/mcp-server-elasticsearch) | 🟢 🔵 🛡️ 💎 | Official Elastic MCP server for Elasticsearch search and mapping access; deprecated in favor of Elastic Agent Builder MCP. |
 
 ### Official Agent Skills and Frameworks
 
@@ -159,12 +181,19 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The list below is a r
 | --- | --- | --- |
 | [databricks-solutions/ai-dev-kit](https://github.com/databricks-solutions/ai-dev-kit) | 🟢 🔵 🛡️ 📊 💎 ⚠️ | Databricks field-engineering AI Dev Kit with Databricks MCP server, Databricks skills, tools core, and builder app support. |
 | [kubeflow/mcp-server](https://github.com/kubeflow/mcp-server) | 🟢 🔵 🛡️ 💎 ⚠️ | Official Kubeflow MCP server for AI-assisted development with Kubeflow tools. |
+| [backstage/backstage (mcp-actions-backend)](https://github.com/backstage/backstage/tree/master/plugins/mcp-actions-backend) | 🟢 🔵 🛡️ 💎 ⚠️ | Official CNCF Backstage plugin that exposes Internal Developer Portal actions as MCP tools for AI agents. |
 
 ### Official Diagramming and Architecture MCP Tools
 
 | Repo | Labels | Operator note |
 | --- | --- | --- |
 | [jgraph/drawio-mcp](https://github.com/jgraph/drawio-mcp) | 🟢 🔵 🛡️ 💎 | draw.io MCP server and Claude Code plugin for generating, opening, and exporting draw.io diagrams with shape search. |
+
+### Official Data Platform MCP Servers
+
+| Repo | Labels | Operator note |
+| --- | --- | --- |
+| [mongodb-js/mongodb-mcp-server](https://github.com/mongodb-js/mongodb-mcp-server) | 🟢 🔵 🛡️ 💎 ⚠️ | Official MongoDB MCP server (public preview) connecting agents to MongoDB Community, Enterprise, and Atlas deployments. |
 
 ### Community Discovery and Skills
 

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1156,3 +1156,202 @@
     - 🟡
     - 🛡️
     - 💎
+
+- name: newrelic/mcp-server
+  url: https://github.com/newrelic/mcp-server
+  category: official-sre-mcp-servers
+  type: mcp-server
+  framework: MCP
+  primary_language: unknown
+  cloud_provider: multi-cloud
+  use_cases:
+    - apm-and-dashboard-context
+    - nrql-querying
+    - incident-and-alert-investigation
+  action_level: read-only
+  human_approval: true
+  evidence_tracing: partial
+  maturity: production-adjacent
+  gemini_opportunity: "Use as the official New Relic MCP source for Gemini SRE copilots that need APM, dashboard, and NRQL context."
+  risk_notes: "Telemetry may include sensitive application and infrastructure data; scope API keys per account and prefer read-only queries."
+  operator_note: "Official New Relic MCP server for connecting AI agents to APM, dashboards, and NRQL-based observability data."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - 📊
+    - 💎
+
+- name: elastic/mcp-server-elasticsearch
+  url: https://github.com/elastic/mcp-server-elasticsearch
+  category: official-sre-mcp-servers
+  type: mcp-server
+  framework: MCP
+  primary_language: unknown
+  cloud_provider: multi-cloud
+  use_cases:
+    - elasticsearch-index-search
+    - log-and-mapping-investigation
+    - query-dsl-generation
+  action_level: read-only
+  human_approval: true
+  evidence_tracing: partial
+  maturity: production-adjacent
+  gemini_opportunity: "Use as a reference for Gemini agents that need natural-language Elasticsearch search, but plan a migration path to Elastic Agent Builder MCP."
+  risk_notes: "Deprecated: Elastic has moved active development to the Agent Builder MCP endpoint (Elastic 9.2+/Serverless); this repo receives critical security fixes only, so pin versions and plan migration."
+  operator_note: "Official Elastic MCP server for Elasticsearch search and mapping access; deprecated in favor of Elastic Agent Builder MCP."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - 💎
+
+- name: cloudflare/mcp-server-cloudflare
+  url: https://github.com/cloudflare/mcp-server-cloudflare
+  category: official-cloud-mcp-servers
+  type: mcp-server-collection
+  framework: MCP
+  primary_language: TypeScript
+  cloud_provider: Cloudflare
+  use_cases:
+    - cloudflare-account-automation
+    - edge-and-worker-configuration
+    - security-and-performance-tuning
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: partial
+  maturity: production-adjacent
+  gemini_opportunity: "Use as the official Cloudflare MCP source for Gemini or Codex agents that configure Workers, DNS, or edge security settings."
+  risk_notes: "Domain-specific servers can read and mutate live Cloudflare account configuration; scope API tokens per zone/account and require approval before write actions."
+  operator_note: "Official Cloudflare MCP servers for account, Workers, and edge configuration workflows, with both curated domain servers and a code-mode server."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - 💎
+    - ⚠️
+
+- name: CircleCI-Public/mcp-server-circleci
+  url: https://github.com/CircleCI-Public/mcp-server-circleci
+  category: official-ci-cd-mcp-servers
+  type: mcp-server
+  framework: MCP
+  primary_language: TypeScript
+  cloud_provider: multi-cloud
+  use_cases:
+    - build-failure-investigation
+    - flaky-test-identification
+    - pipeline-and-usage-analysis
+  action_level: read-only
+  human_approval: true
+  evidence_tracing: partial
+  maturity: production-adjacent
+  gemini_opportunity: "Use as the official CircleCI MCP source for Gemini agents that triage build failures, flaky tests, and pipeline usage before proposing fixes."
+  risk_notes: "Access exposes build logs and usage data; scope CircleCI API tokens per project and keep write-capable pipeline triggers behind explicit approval."
+  operator_note: "Official CircleCI MCP server for build failure logs, pipeline status, flaky test detection, and usage analysis."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - 📊
+    - 💎
+
+- name: mongodb-js/mongodb-mcp-server
+  url: https://github.com/mongodb-js/mongodb-mcp-server
+  category: official-data-platform-mcp-servers
+  type: mcp-server
+  framework: MCP
+  primary_language: TypeScript
+  cloud_provider: multi-cloud
+  use_cases:
+    - mongodb-atlas-administration
+    - database-schema-and-query-inspection
+    - data-platform-agent-workflows
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: partial
+  maturity: production-adjacent
+  gemini_opportunity: "Use as the official MongoDB MCP source for Gemini or Codex agents that inspect schemas, run queries, or manage Atlas clusters."
+  risk_notes: "Public preview; can run database operations and Atlas API actions, so require least-privilege connection strings and disable destructive operations by default."
+  operator_note: "Official MongoDB MCP server connecting agents to MongoDB Community, Enterprise, and Atlas deployments."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - 💎
+    - ⚠️
+
+- name: vercel/vercel-mcp-overview
+  url: https://github.com/vercel/vercel-mcp-overview
+  category: official-cloud-mcp-servers
+  type: hosted-mcp-server
+  framework: MCP
+  primary_language: unknown
+  cloud_provider: multi-cloud
+  use_cases:
+    - vercel-project-and-deployment-context
+    - serverless-app-automation
+    - remote-mcp-hosting
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: partial
+  maturity: production-adjacent
+  gemini_opportunity: "Use as the official Vercel MCP overview when connecting Gemini or Codex agents to the hosted mcp.vercel.com endpoint for project and deployment context."
+  risk_notes: "The hosted remote MCP can read and mutate live Vercel projects and deployments; use OAuth-scoped access and require approval before deploy or config changes."
+  operator_note: "Official public overview of Vercel's hosted MCP server, documented at vercel.com/docs/mcp/vercel-mcp; this repo tracks the docs, not a standalone local server."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - 💎
+    - ⚠️
+
+- name: hashicorp/vault-mcp-server
+  url: https://github.com/hashicorp/vault-mcp-server
+  category: official-iac-mcp-servers
+  type: mcp-server
+  framework: MCP
+  primary_language: Go
+  cloud_provider: multi-cloud
+  use_cases:
+    - secrets-and-mount-inspection
+    - vault-policy-review
+    - secrets-management-automation
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: partial
+  maturity: prototype
+  gemini_opportunity: "Use as the official HashiCorp Vault MCP baseline for Gemini agents that need governed secrets-management context alongside Terraform MCP workflows."
+  risk_notes: "Beta; tools can touch live secrets engines and mounts, so run locally only, avoid exposing it to other network users, and require approval before write operations."
+  operator_note: "Official HashiCorp Vault MCP server for secrets and mount management, complementing the Terraform MCP server for IaC workflows."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - 💎
+    - ⚠️
+
+- name: backstage/backstage (plugins/mcp-actions-backend)
+  url: https://github.com/backstage/backstage/tree/master/plugins/mcp-actions-backend
+  category: official-platform-agent-toolkits
+  type: mcp-plugin
+  framework: MCP + Backstage
+  primary_language: TypeScript
+  cloud_provider: multi-cloud
+  use_cases:
+    - internal-developer-portal-actions
+    - software-catalog-automation
+    - agent-exposed-plugin-actions
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: partial
+  maturity: production-adjacent
+  gemini_opportunity: "Use as the official Backstage MCP actions bridge for Gemini agents that need to discover and invoke Internal Developer Portal actions from the software catalog."
+  risk_notes: "Exposes registered plugin actions, some of which can mutate catalog entities or trigger scaffolder templates; scope static tokens or OAuth per environment and review each action's write scope."
+  operator_note: "Official CNCF Backstage plugin that exposes registered plugin actions as MCP tools for AI agents like Claude, Cursor, and internal assistants."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - 💎
+    - ⚠️

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -39,7 +39,7 @@ def valid_entry(**overrides):
 def test_validates_seed_data_file():
     entries = validate_file(Path("data/repos.yaml"))
 
-    assert len(entries) == 47
+    assert len(entries) == 55
     assert all(field in entries[0] for field in REQUIRED_FIELDS)
 
 


### PR DESCRIPTION
## Summary
- Adds 8 new official, web-verified entries: New Relic, Elastic (flagged deprecated), Cloudflare, CircleCI, MongoDB, Vercel, HashiCorp Vault, and Backstage's MCP actions plugin — filling gaps in SRE/observability, CI/CD, IaC/secrets, edge/cloud, and a new Data Platform category.
- Polishes README.md: badges (license, CI, PRs welcome), a table of contents, and a new "Official Data Platform MCP Servers" section/category.
- Lowers contribution friction: adds `.github/ISSUE_TEMPLATE/new-entry.yml` (structured entry-suggestion form) and `.github/PULL_REQUEST_TEMPLATE.md` (mirrors CONTRIBUTING.md's checklist).
- Bumps the hardcoded entry-count assertion in `tests/test_repos_yaml.py` from 47 to 55.

## Test plan
- [x] `python scripts/validate_repos_yaml.py` — 55 entries validate
- [x] `pytest -q` — 32 passed
- [x] `python scripts/run_mock_eval_scenarios.py` — 7/7 passed
- [x] `python scripts/audit_github_repos.py --workers 12` — 47/55 reachable, 8 skipped (non-GitHub doc links), 0 archived/unreachable, including all 8 new entries confirmed live