### PR TITLE
docs: explain how entries are scored in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository evaluates which agents are safe, useful, and production-adjacent
 - [Who it is for](#who-it-is-for)
 - [Safety-first disclaimer](#safety-first-disclaimer)
 - [Evaluation labels](#evaluation-labels)
+- [How entries are scored](#how-entries-are-scored)
 - [Categories](#categories)
 - [Top picks by use case](#top-picks-by-use-case)
 - [Curated catalog](#curated-catalog)
@@ -48,6 +49,37 @@ These agents may touch infrastructure. Prefer read-only or proposal mode first. 
 | 🛡️ | has approval/safety controls |
 | 📊 | has tracing/evidence/evals |
 | ⚠️ | write-capable; review before use |
+
+Labels are shorthand for structured fields recorded on every entry in [data/repos.yaml](data/repos.yaml): ⚠️ maps to `action_level: write-capable`, 🛡️ to `human_approval: true`, 📊 to tracing or eval evidence, and 🟢/🟡 to `maturity`.
+
+## How entries are scored
+
+Every entry records five verifiable dimensions. They are assessed by reading each project's documentation and exposed tool surface, not its marketing.
+
+| Field | Question it answers | How it is verified |
+| --- | --- | --- |
+| `action_level` | Can it touch production? | Read the project's exposed tool list. Only query tools (`get`, `list`, `search`) means `read-only`. Suggesting changes for a human to execute means `proposal`. Any tool that mutates real state (`create`, `deploy`, `delete`, `sync`) means `write-capable` and the entry gets ⚠️. |
+| `human_approval` | Does a human gate write actions? | Look for gates in the server (write tools disabled by default, dry-run modes, confirmation flags) or in the client (permission prompts). Server-side gates are stronger because they hold no matter which client connects. |
+| `evidence_tracing` | Can you prove what it did afterward? | Check for audit logs, OpenTelemetry support, structured run records, or evaluation output. Scored `yes`, `partial`, or `none`. |
+| `maturity` | Is it stable enough to depend on? | Observable signals only: vendor support status, API stability (GA versus alpha), and recent activity. The audit script checks freshness and archived status automatically. |
+| `risk_notes` | What is the blast radius if it goes wrong? | Combines the above with what the tool connects to. Write-capable identity tooling is treated very differently from a read-only diagram generator. |
+
+### Example: reading one entry
+
+```yaml
+- name: PagerDuty/pagerduty-mcp-server
+  action_level: write-capable    # tools can create incidents and schedule overrides
+  human_approval: true           # write tools ship disabled by default
+  evidence_tracing: partial      # logs exist, but no structured trace guarantee
+  maturity: production-adjacent  # official vendor server
+  risk_notes: "Keep write tools disabled by default and require approval for changes."
+```
+
+Read as: safe to connect for incident context today, but flip on its write tools only after you have decided who approves an agent-created incident.
+
+### What is automated and what is judgment
+
+Link reachability, archived status, and freshness are checked automatically by [scripts/audit_github_repos.py](scripts/audit_github_repos.py) and enforced in CI. The safety scores themselves are curator judgment from reviewing each project's docs and tool surface at the time of entry. Verify against your own environment before connecting anything to real infrastructure — [templates/agent-scorecard.md](templates/agent-scorecard.md) is the full per-project checklist used for deep review.
 
 ## Categories
 


### PR DESCRIPTION
## Summary
The README promised entries "scored by real infrastructure usefulness, operational risk, human approval gates, tracing/evidence, and maturity" but never defined those terms or said how they are assessed — even the maintainer had to ask. This PR closes that gap, docs-only:

- New **"How entries are scored"** section between Evaluation labels and Categories: a table mapping each `data/repos.yaml` field (`action_level`, `human_approval`, `evidence_tracing`, `maturity`, `risk_notes`) to the question it answers and how it is verified (tool-surface inspection, server vs client gates, audit/OTel evidence, GA-vs-alpha signals, blast radius).
- The `read-only` / `proposal` / `write-capable` vocabulary is now defined for readers, not just contributors in CONTRIBUTING.md.
- **Annotated example entry** (PagerDuty) showing how to read the fields in 20 seconds, ending with the operational takeaway.
- A sentence under the emoji legend tying labels to the structured fields (⚠️ = write-capable, 🛡️ = human approval, 📊 = tracing evidence, 🟢/🟡 = maturity).
- **"What is automated and what is judgment"** honesty note: CI checks reachability/freshness; safety scores are curator judgment — with a pointer to `templates/agent-scorecard.md` as the deep-review checklist.
- TOC updated with the new anchor.

## Test plan
- [x] `python scripts/validate_repos_yaml.py` — 55 entries validate
- [x] `pytest -q` — 32 passed
- [x] TOC anchors match headings; all tables well-formed (verified with awk pipe-count check)