### PR TITLE
docs: add Recently added section and weekly link audit in CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 jobs:
   validate:
@@ -31,3 +34,25 @@ jobs:
 
       - name: Run mock eval scenarios
         run: python scripts/run_mock_eval_scenarios.py
+
+  audit-links:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Audit catalog links
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/audit_github_repos.py --workers 12 --fail-on-unreachable

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 
 **Awesome Agentic DevOps** is a curated map for DevOps, Cloud, SRE, and Platform Engineering agents across Claude Code, Gemini ADK, OpenAI Agents SDK, and MCP.
 
-This repository evaluates which agents are safe, useful, and production-adjacent for infrastructure automation.
+This repository evaluates which agents are safe, useful, and production-adjacent for infrastructure automation. Every link is re-audited by scheduled CI for reachability, archival, and freshness.
 
 ## Contents
 
+- [Recently added](#recently-added)
 - [Why this exists](#why-this-exists)
 - [Who it is for](#who-it-is-for)
 - [Safety-first disclaimer](#safety-first-disclaimer)
@@ -19,6 +20,16 @@ This repository evaluates which agents are safe, useful, and production-adjacent
 - [Top picks by use case](#top-picks-by-use-case)
 - [Curated catalog](#curated-catalog)
 - [How to contribute](#how-to-contribute)
+
+## Recently added
+
+| Date | Entry | Category |
+| --- | --- | --- |
+| 2026-07-05 | [hashicorp/vault-mcp-server](https://github.com/hashicorp/vault-mcp-server) | IaC / secrets management |
+| 2026-07-05 | [cloudflare/mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare) | Cloud / edge |
+| 2026-07-05 | [CircleCI-Public/mcp-server-circleci](https://github.com/CircleCI-Public/mcp-server-circleci) | CI/CD |
+| 2026-07-05 | [mongodb-js/mongodb-mcp-server](https://github.com/mongodb-js/mongodb-mcp-server) | Data platform |
+| 2026-07-05 | [backstage/backstage (mcp-actions-backend)](https://github.com/backstage/backstage/tree/master/plugins/mcp-actions-backend) | Platform toolkits |
 
 ## Why this exists
 


### PR DESCRIPTION
## Summary
Part of the star-growth work: give visitors proof the list is alive, and make the freshness claim enforceable.

- **"Recently added" section** at the top of the README (dated table of the 5 most recent entries) with a TOC link — the first thing people check before starring an awesome list is whether it's maintained.
- **Weekly scheduled CI audit**: `validate.yml` gains `schedule` (Mondays 06:00 UTC) and `workflow_dispatch` triggers plus an `audit-links` job that runs `scripts/audit_github_repos.py --workers 12 --fail-on-unreachable`, authenticated with the built-in workflow token (the script shells out to `gh`, which picks up `GH_TOKEN`). The job only runs on schedule/dispatch so PR CI stays fast.
- Intro sentence now states links are re-audited by scheduled CI — a differentiator most awesome lists can't claim.

Security note: the new job interpolates only `${{ github.token }}` into an `env:` block; no untrusted event data reaches `run:` commands.

## Test plan
- [x] Workflow YAML parses (`yaml.safe_load`)
- [x] `python scripts/validate_repos_yaml.py` — 55 entries
- [x] `pytest -q` — 32 passed
- [x] README tables well-formed; new TOC anchor matches heading
- [ ] After merge: trigger the `audit-links` job once via workflow_dispatch to confirm it passes in Actions