### PR TITLE
docs: add skyhook-io/radar as a community Kubernetes MCP entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repository evaluates which agents are safe, useful, and production-adjacent
 
 | Date | Entry | Category |
 | --- | --- | --- |
+| 2026-07-07 | [skyhook-io/radar](https://github.com/skyhook-io/radar) | Kubernetes / community MCP |
 | 2026-07-07 | [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top-10/) | Agent security / MCP risk framework |
 | 2026-07-06 | [vantage-sh/vantage-mcp-server](https://github.com/vantage-sh/vantage-mcp-server) | FinOps / cloud cost |
 | 2026-07-05 | [hashicorp/vault-mcp-server](https://github.com/hashicorp/vault-mcp-server) | IaC / secrets management |
@@ -256,6 +257,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The list below is a r
 | [antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill) | 🟡 🛡️ | Community Terraform-specific prompt and workflow reference. |
 | [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) | 🟢 🛡️ | Community engineering skill reference; useful style and structure input for DevOps-specific skills. |
 | [Agents365-ai/drawio-skill](https://github.com/Agents365-ai/drawio-skill) | 🟡 🛡️ | Community draw.io skill for natural-language diagram generation, visual self-checking, and exports. |
+| [skyhook-io/radar](https://github.com/skyhook-io/radar) | 🟢 🔵 🛡️ 📊 ⚠️ | Community open-source Kubernetes UI with a built-in MCP server: read-only cluster/topology/event queries plus RBAC-scoped write and GitOps/Helm tools for AI-assisted operations. |
 
 ## How to contribute
 

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1292,3 +1292,26 @@
     - 🛡️
     - 📊
     - ⚠️
+- name: skyhook-io/radar
+  url: https://github.com/skyhook-io/radar
+  category: community-mcp-servers
+  type: mcp-server
+  framework: MCP + Kubernetes
+  primary_language: Go
+  cloud_provider: multi-cloud
+  use_cases:
+    - kubernetes-cluster-visibility
+    - gitops-and-helm-operations
+    - ai-assisted-cluster-triage
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: "yes"
+  maturity: production-adjacent
+  risk_notes: "Write tools (restart, scale, GitOps sync/rollback, Helm writes) act on live clusters and can disrupt workloads; they run under the cluster's RBAC and carry destructive-action hints, and Helm/terminal/MCP surfaces can be disabled via flags. Community (non-official) project - scope RBAC per identity and require approval before mutating tools."
+  operator_note: "Community open-source Kubernetes UI with a built-in MCP server exposing read-only cluster/topology/event queries plus RBAC-scoped write and GitOps/Helm tools for AI-assisted operations."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - 📊
+    - ⚠️

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -38,7 +38,7 @@ def valid_entry(**overrides):
 def test_validates_seed_data_file():
     entries = validate_file(Path("data/repos.yaml"))
 
-    assert len(entries) == 57
+    assert len(entries) == 58
     assert all(field in entries[0] for field in REQUIRED_FIELDS)
 
 


### PR DESCRIPTION
## Summary
Adds `skyhook-io/radar` to the **Community** section — a community (non-official) open-source Kubernetes UI with a built-in MCP server, surfaced from the r/devops announcement thread as a Kubernetes-native gap-filler.

- New `data/repos.yaml` entry under `community-mcp-servers` (58 entries total).
- README: row in the "Community Discovery and Skills" table + a "Recently added" row (2026-07-07).
- `tests/test_repos_yaml.py`: entry-count assertion bumped `57 → 58`.

## Why these labels/fields (verified against the repo, not marketing)
Verified `skyhook-io/radar` via `gh repo view` and its README/MCP docs:
- **Active, legit**: Apache-2.0, Go, ~2.5k stars, pushed 2026-07-07, not archived; `mcp-server` is a declared repo topic.
- **`action_level: write-capable` (⚠️)**: read tools are strictly read-only, but write tools exist — `restart`, `scale`, `manage_gitops` (sync/suspend/resume/reconcile/rollback), and Helm writes.
- **`human_approval: true` (🛡️)**: writes run under the cluster's RBAC (apiserver-enforced per identity), destructive tools carry explicit destructive-action hints, and Helm/terminal/MCP surfaces can be disabled via flags (`--disable-helm-write`, `--no-mcp`, `--disable-local-terminal`).
- **`evidence_tracing: yes` (📊)**: exposes `get_cluster_audit`, an event timeline, and `get_subject_permissions` (RBAC blast-radius) MCP tools.
- **`maturity: production-adjacent` (🟢)**: in-cluster Helm deploy with RBAC scoping and releases. Community placement (not 🟢-official) is captured by the **section**, not by downgrading the maturity label.

## Test plan
- [x] `.venv/bin/python3 scripts/validate_repos_yaml.py` — `Validation passed: 58 repo entries`
- [x] `.venv/bin/python3 -m pytest -q` — `32 passed`
- [x] `.venv/bin/python3 scripts/run_mock_eval_scenarios.py` — ran clean
- [x] Row-count parity: yaml 58 == README catalog rows 58
- [x] New link (`skyhook-io/radar`) verified reachable/active directly via `gh repo view`

## Note
The Community section heading is "Community Discovery and Skills"; radar is a functional MCP server rather than a discovery list or skill, so it slightly stretches the heading. Left as-is to minimize churn — happy to rename the section (and category #13) to "Community discovery, skills, and tools" in a follow-up if you'd prefer.