### PR TITLE
Add Aient (agentic SRE remediation MCP) to SRE catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repository evaluates which agents are safe, useful, and production-adjacent
 
 | Date | Entry | Category |
 | --- | --- | --- |
+| 2026-07-09 | [Aient](https://docs.aient.ai) | SRE / observability (agentic remediation) |
 | 2026-07-08 | [Elastic Agent Builder MCP server docs](https://www.elastic.co/docs/explore-analyze/ai-features/agent-builder/mcp-server) | SRE / observability |
 | 2026-07-07 | [skyhook-io/radar](https://github.com/skyhook-io/radar) | Kubernetes / community MCP |
 | 2026-07-07 | [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top-10/) | Agent security / MCP risk framework |
@@ -222,6 +223,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The list below is a r
 | [PagerDuty/pagerduty-mcp-server](https://github.com/PagerDuty/pagerduty-mcp-server) | 🟢 🔵 🛡️ ⚠️ | Official PagerDuty MCP server for incidents, services, schedules, event orchestrations, and embedded incident UIs. |
 | [newrelic/mcp-server](https://github.com/newrelic/mcp-server) | 🟢 🔵 🛡️ 📊 | Official New Relic MCP server for APM, dashboard, and NRQL-based observability context. |
 | [Elastic Agent Builder MCP server docs](https://www.elastic.co/docs/explore-analyze/ai-features/agent-builder/mcp-server) | 🟢 🔵 🛡️ 📊 | Official Elastic documentation for exposing Agent Builder tools through MCP with Kibana URL and API-key authentication. |
+| [Aient](https://docs.aient.ai) | 🟡 🔵 🛡️ 📊 ⚠️ | Commercial agentic SRE product with a hosted MCP server: ingests OpenTelemetry logs, metrics, and traces, groups errors into problems, and an AI agent opens GitHub remediation pull requests it then monitors for recurrence. Early access; closed source. |
 
 ### Official Agent Skills and Frameworks
 

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1132,6 +1132,30 @@
     - 🛡️
     - 📊
 
+- name: Aient
+  url: https://docs.aient.ai
+  category: official-sre-mcp-servers
+  type: hosted-mcp-server
+  framework: MCP + OpenTelemetry + remediation agent
+  primary_language: unknown
+  cloud_provider: multi-cloud
+  use_cases:
+    - error-and-crash-detection
+    - automated-root-cause-analysis
+    - remediation-pull-requests
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: "yes"
+  maturity: prototype
+  risk_notes: "Commercial, closed-source, early-access product (not GA). Connecting it ingests application logs, metrics, and traces that can contain sensitive data; with the aient.mcp.write scope an agent can request remediation, resolve/mute problems, and create API keys or telemetry drains. Remediation lands as a GitHub pull request for human review and merge rather than a direct production write, and post-merge verification is a passive telemetry-recurrence check, not causal proof. Scope publishable/API keys per environment and keep the write scope gated."
+  operator_note: "Commercial agentic SRE product with a hosted MCP server: ingests OpenTelemetry logs, metrics, and traces, groups errors into problems, and an AI agent opens GitHub remediation pull requests it then monitors for recurrence. OTel-native with structured per-run thread records/artifacts and a CloudEvents webhook stream. Early access; closed source."
+  labels:
+    - 🟡
+    - 🔵
+    - 🛡️
+    - 📊
+    - ⚠️
+
 - name: cloudflare/mcp-server-cloudflare
   url: https://github.com/cloudflare/mcp-server-cloudflare
   category: official-cloud-mcp-servers

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -38,7 +38,7 @@ def valid_entry(**overrides):
 def test_validates_seed_data_file():
     entries = validate_file(Path("data/repos.yaml"))
 
-    assert len(entries) == 58
+    assert len(entries) == 59
     assert all(field in entries[0] for field in REQUIRED_FIELDS)
 
 


### PR DESCRIPTION
## Summary

Adds **Aient** to the Official SRE MCP Servers category. Aient is an OpenTelemetry-native SRE product with a hosted MCP server: it ingests logs, metrics, and traces, groups errors into problems, and an AI agent opens GitHub remediation pull requests it then monitors for recurrence.

**Disclosure:** I maintain Aient AI — this is a vendor self-submission. I've tried to score it to the list's no-hype standard rather than its marketing, and to under-claim rather than over-claim where uncertain. Happy to adjust any field or drop it if it isn't a fit.

Scoring rationale (verifiable from the docs and the exposed tool surface):

| Field | Value | Why |
| --- | --- | --- |
| `action_level` | `write-capable` ⚠️ | With the `aient.mcp.write` scope, tools can request remediation, resolve/mute problems, and create API keys / telemetry drains. |
| `human_approval` | `true` 🛡️ | Code remediation lands as a **GitHub PR for human review and merge** — not a direct production write. Write tools sit behind a separate `aient.mcp.write` scope from read. |
| `evidence_tracing` | `yes` 📊 | OTel-native; structured per-run thread records/artifacts; CloudEvents webhook stream for the problem/remediation lifecycle. |
| `maturity` | `prototype` 🟡 | Commercial, closed-source, **early-access (not GA)** — deliberately not scored 🟢. |

I've also noted honestly in `risk_notes` that telemetry can carry sensitive data and that post-merge verification is a passive telemetry-recurrence check, not causal proof.

URL used is the public docs site (https://docs.aient.ai), reachable and non-gated; the MCP endpoint itself requires auth as expected. This matches how other docs/hosted entries (Splunk, Elastic, Datadog) are listed — the audit script skips non-GitHub URLs.

## Entry checklist

- [x] The repo URL is public and reachable.
- [x] The entry has a specific category. (`official-sre-mcp-servers`)
- [x] The `risk_notes` field explains what could go wrong.
- [x] The `operator_note` field explains why an infrastructure operator should care.
- [x] Labels match the observed behavior, not marketing claims.
- [x] `data/repos.yaml` and `README.md` are both updated.

Commercial-only / closed-source is disclosed in both `risk_notes` and `operator_note`.

## Validation

```bash
python scripts/validate_repos_yaml.py      # Validation passed: 59 repo entries
pytest -q                                  # 32 passed
python scripts/run_mock_eval_scenarios.py  # Mock eval complete: 7/7 passed
```

All pass locally. `audit_github_repos.py` skips the entry as a non-GitHub URL (same as the Splunk/Elastic/Datadog docs entries), so `--fail-on-unreachable` is unaffected. The hardcoded entry-count assertion in `tests/test_repos_yaml.py` is bumped 58 → 59.