### PR TITLE
chore: add community issue hygiene

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: true
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/report-broken-link.yml
+++ b/.github/ISSUE_TEMPLATE/report-broken-link.yml
@@ -1,0 +1,65 @@
+name: Report a broken or stale catalog link
+description: Report unreachable, archived, renamed, or stale entries in the catalog.
+title: "Broken/stale link: "
+labels:
+  - broken-link
+  - catalog-maintenance
+body:
+  - type: input
+    id: entry
+    attributes:
+      label: Catalog entry
+      description: Name of the affected entry from README.md or data/repos.yaml.
+      placeholder: github/github-mcp-server
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: Current URL
+      description: Paste the current URL that is broken, stale, archived, or redirected.
+      placeholder: https://github.com/org/repo
+    validations:
+      required: true
+
+  - type: dropdown
+    id: problem
+    attributes:
+      label: What is wrong?
+      options:
+        - Unreachable or 404
+        - Archived or deprecated
+        - Redirected or renamed
+        - Documentation moved
+        - Safety/risk notes are stale
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: replacement
+    attributes:
+      label: Replacement URL, if known
+      description: Prefer official/vendor docs or repositories.
+      placeholder: https://docs.vendor.example/mcp
+    validations:
+      required: false
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Add HTTP status, archive notice, deprecation notice, vendor docs link, or other proof.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Reporter checklist
+      options:
+        - label: I checked that the issue affects the current README.md or data/repos.yaml entry.
+          required: true
+        - label: I did not paste secrets, tokens, private URLs, or internal logs.
+          required: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience.
+- Focusing on what is best not just for us as individuals, but for the overall community.
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or email address, without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement responsibilities
+
+Project maintainers are responsible for clarifying and enforcing standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, pull requests, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and also applies when an individual is officially representing the project in public spaces.
+
+Examples of representing the project include using an official email address, posting through an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers by opening a private communication channel with the repository owner or by emailing the maintainer address listed on the repository profile.
+
+All complaints will be reviewed and investigated promptly and fairly. Maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement guidelines
+
+Maintainers will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community impact:** Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written warning from maintainers, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community impact:** A violation through a single incident or series of actions.
+
+**Consequence:** A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary ban
+
+**Community impact:** A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence:** A temporary ban from any sort of interaction or public communication with the community for a specified period of time. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent ban
+
+**Community impact:** Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence:** A permanent ban from any sort of public interaction within the project community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.


### PR DESCRIPTION
## Summary
- Add Contributor Covenant Code of Conduct for community health
- Add a structured broken/stale catalog link issue template
- Disable blank issues so catalog reports use templates and avoid missing safety context

## Validation
- [x] python3 scripts/validate_repos_yaml.py
- [x] /Users/tuximac/projects/awesome-agentic-devops/.venv/bin/python -m pytest -q