### PR TITLE
ci: move the link audit to its own workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,32 @@
+# Live reachability/archival/freshness audit of every catalog link.
+# Deliberately not run on pull requests: it makes network requests to all
+# external vendor sites, so a vendor outage would fail unrelated PRs. Runs
+# weekly and on demand (gh workflow run audit.yml --ref main).
+name: Audit links
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  audit-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Audit catalog links
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/audit_github_repos.py --workers 12 --fail-on-unreachable

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -30,3 +30,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: python scripts/audit_github_repos.py --workers 12 --fail-on-unreachable
+
+      # Publish results even when the audit fails — that is when they matter most.
+      - name: Post report to the run summary
+        if: always()
+        run: cat reports/github-repo-audit.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: github-repo-audit
+          path: reports/

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: "0 6 * * 1"
   workflow_dispatch:
 
 jobs:
@@ -34,25 +32,3 @@ jobs:
 
       - name: Run mock eval scenarios
         run: python scripts/run_mock_eval_scenarios.py
-
-  audit-links:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
-
-      - name: Audit catalog links
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: python scripts/audit_github_repos.py --workers 12 --fail-on-unreachable


### PR DESCRIPTION
## Summary

The `audit-links` job lived in `validate.yml` gated by `if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'`, so every pull request's check list showed it as a grey **Skipped** entry — noise that invites the question this PR removes.

- New `.github/workflows/audit.yml` holds the job with only `schedule` (Mondays 06:00 UTC, unchanged) and `workflow_dispatch` triggers, plus a comment explaining why it deliberately skips PRs (live network calls to all vendor links; an external outage shouldn't fail unrelated PRs).
- `validate.yml` drops the job and the `schedule` trigger it only carried for the audit. The `validate` job (schema, tests, mock evals) is untouched, so the required status check for branch protection is unaffected.
- On-demand run command changes to: `gh workflow run audit.yml --ref main`.

## Test plan

- [x] Job steps are byte-identical to the previous audit-links job (only the trigger moved)
- [x] `validate` job untouched — required status check context unchanged
- [x] No event-derived inputs in either workflow (no injection surface)
- [ ] After merge: `gh workflow run audit.yml --ref main` to confirm the manual trigger works