### PR TITLE
docs: clarify catalog scope and audit guarantees

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Validate repo data
         run: python scripts/validate_repos_yaml.py
 
+      - name: Check README catalog counts
+        run: python scripts/sync_readme_counts.py --check
+
       - name: Run tests
         run: pytest -q
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 [![CI](https://github.com/DevOpsAIguru123/awesome-agentic-devops/actions/workflows/validate.yml/badge.svg)](https://github.com/DevOpsAIguru123/awesome-agentic-devops/actions/workflows/validate.yml)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-A curated catalog of **official** DevOps, Cloud, SRE, and Platform Engineering MCP servers and agent skills, for teams evaluating AI automation against real infrastructure.
+A curated, **official-first** catalog of MCP servers, agent skills, AI agents, frameworks, and supporting resources for DevOps, Cloud, SRE, and Platform Engineering. It includes vendor and open-source project resources alongside a clearly labeled community-driven section.
 
 Most agent lists stop at discovery. This one is built for operators:
 
-- **Official-first** — 59 entries across 14 categories, all but a clearly labeled [community section](#community-discovery-and-skills) verified as the vendor's own repo or docs.
-- **Scored, not just listed** — every entry rates production access, human approval gates, tracing evidence, and maturity ([how entries are scored](docs/scoring.md)).
-- **Audited by CI** — every link is re-checked weekly for reachability, archival, and freshness.
-- **Installable, not just readable** — [one command](#install-official-skills-into-your-coding-agent) puts 300+ official skills from Google, Microsoft, and Azure into Claude Code, Cursor, Codex, VS Code, or Antigravity.
-- **Runnable, not just theoretical** — working [reference agents](#local-reference-agents) for Terraform plan review and drift detection (more agents coming soon).
+- **Official-first, community-inclusive** — 59 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
+- **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
+- **Audited by CI** — GitHub repository entries are checked weekly for reachability and archived status; non-GitHub documentation links are outside this automated check and require curator review.
+- **Installable, not just readable** — [one command](#install-official-skills-into-your-coding-agent) installs hundreds of official skills from cataloged Google, Microsoft, Azure, and Azure DevOps sources into Claude Code, Cursor, Codex, VS Code, or Antigravity.
+- **Runnable, not just theoretical** — documented [reference-agent examples](#local-reference-agents) cover Terraform plan review and drift detection.
 
-**Safety first:** these agents may touch infrastructure. Prefer read-only or proposal mode, require human approval before write actions, and use least-privilege credentials — full guidance in the [safety model](docs/safety-model.md).
+**Safety first:** some cataloged tools and agents can change infrastructure. Prefer read-only or proposal mode, require human approval before write actions, and use least-privilege credentials — full guidance in the [safety model](docs/safety-model.md).
 
 ## Contents
 
@@ -30,10 +30,10 @@ Most agent lists stop at discovery. This one is built for operators:
 
 | Label | Meaning |
 | --- | --- |
-| 🟢 | production-adjacent OSS |
-| 🟡 | useful prototype |
+| 🟢 | assessed as production-adjacent; not a readiness guarantee |
+| 🟡 | assessed as a useful prototype |
 | 🔵 | MCP/server integration |
-| 🛡️ | has approval/safety controls |
+| 🛡️ | documents an approval or safety mechanism; enforcement varies |
 | 📊 | has tracing/evidence/evals |
 | ⚠️ | write-capable; review before use |
 
@@ -58,7 +58,7 @@ Labels are shorthand for structured fields recorded on every entry in [data/repo
 
 ## Install official skills into your coding agent
 
-Install official [Agent Skills](https://github.com/anthropics/skills) from every `official-agent-skills` source in this catalog — Google (72), Microsoft (191), Azure (33), and Azure DevOps (6) — with one command:
+Install hundreds of official [Agent Skills](https://github.com/anthropics/skills) from the cataloged Google, Microsoft, Azure, and Azure DevOps sources with one command:
 
 ```bash
 # Claude Code, macOS/Linux — installs every official skill into ~/.claude/skills/
@@ -93,7 +93,7 @@ This repo keeps runnable reference agents under [`agents/`](agents/).
 
 ## Curated catalog
 
-The source of truth is [data/repos.yaml](data/repos.yaml). The list below is a readable index of the current official and community research-backed entries.
+The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines official vendor and open-source project resources with a dedicated section for community-driven tools and references. Entries include executable software as well as SDKs, documentation, security frameworks, registries, and other ecosystem resources.
 
 ### Official Cloud MCP Servers and Agent Toolkits
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -1,20 +1,20 @@
 # How entries are scored
 
-Most agent lists stop at discovery. Infrastructure teams need more: whether an agent can touch production, whether it has approval gates, whether it preserves evidence, and whether it is stable enough to depend on. Every entry in [data/repos.yaml](../data/repos.yaml) records five verifiable dimensions, assessed by reading each project's documentation and exposed tool surface — not its marketing.
+Most agent lists stop at discovery. Infrastructure teams need more: whether a tool can perform write actions, whether it has approval gates, whether it preserves evidence, and whether it is stable enough to depend on. Every entry in [data/repos.yaml](../data/repos.yaml) records five dimensions, assessed from project documentation and exposed tool surfaces rather than marketing claims.
 
 ## The five fields
 
 | Field | Question it answers | How it is verified |
 | --- | --- | --- |
-| `action_level` | Can it touch production? | Read the project's exposed tool list. Only query tools (`get`, `list`, `search`) means `read-only`. Suggesting changes for a human to execute means `proposal`. Any tool that mutates real state (`create`, `deploy`, `delete`, `sync`) means `write-capable` and the entry gets ⚠️. |
+| `action_level` | What kinds of actions can it perform? | Read the project's exposed tool list. Only query tools (`get`, `list`, `search`) means `read-only`. Suggesting changes for a human to execute means `proposal`. Any tool that mutates real state (`create`, `deploy`, `delete`, `sync`) means `write-capable` and the entry gets ⚠️. This classification does not prove the tool has access to a production environment. |
 | `human_approval` | Does a human gate write actions? | Look for gates in the server (write tools disabled by default, dry-run modes, confirmation flags) or in the client (permission prompts). Server-side gates are stronger because they hold no matter which client connects. |
 | `evidence_tracing` | Can you prove what it did afterward? | Check for audit logs, OpenTelemetry support, structured run records, or evaluation output. Scored `yes`, `partial`, or `none`. |
-| `maturity` | Is it stable enough to depend on? | Observable signals only: vendor support status, API stability (GA versus alpha), and recent activity. The audit script checks freshness and archived status automatically. |
+| `maturity` | How mature does the project appear? | Observable signals include vendor support status, API stability (GA versus alpha), and recent activity. A production-adjacent rating is curator judgment, not a production-readiness guarantee. The weekly audit automatically checks GitHub reachability and archived status. |
 | `risk_notes` | What is the blast radius if it goes wrong? | Combines the above with what the tool connects to. Write-capable identity tooling is treated very differently from a read-only diagram generator. |
 
 ## How fields map to README labels
 
-The emoji labels in the README catalog are shorthand for these fields: ⚠️ maps to `action_level: write-capable`, 🛡️ to `human_approval: true`, 📊 to tracing or eval evidence, and 🟢/🟡 to `maturity`.
+The emoji labels in the README catalog are shorthand for these fields: ⚠️ maps to `action_level: write-capable`, 🛡️ to `human_approval: true`, 📊 to tracing or eval evidence, and 🟢/🟡 to `maturity`. A 🛡️ may represent a server-enforced gate, a client permission prompt, or another documented safety mechanism; consult the entry and upstream documentation to determine enforcement strength.
 
 ## Example: reading one entry
 
@@ -31,4 +31,4 @@ Read as: safe to connect for incident context today, but flip on its write tools
 
 ## What is automated and what is judgment
 
-Link reachability, archived status, and freshness are checked automatically by [scripts/audit_github_repos.py](../scripts/audit_github_repos.py) and enforced in CI. The safety scores themselves are curator judgment from reviewing each project's docs and tool surface at the time of entry. Verify against your own environment before connecting anything to real infrastructure — [templates/agent-scorecard.md](../templates/agent-scorecard.md) is the full per-project checklist used for deep review.
+GitHub repository reachability and archived status are checked weekly by [scripts/audit_github_repos.py](../scripts/audit_github_repos.py). The audit records each repository's latest push timestamp but does not apply a freshness threshold, and it skips non-GitHub documentation links. Those links and all safety scores require curator review. Verify every entry against your own environment before connecting it to real infrastructure — [templates/agent-scorecard.md](../templates/agent-scorecard.md) is the full per-project checklist used for deep review.

--- a/scripts/sync_readme_counts.py
+++ b/scripts/sync_readme_counts.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Keep the README intro's catalog counts in sync with data/repos.yaml.
 
-The intro pitch states "<N> entries across <M> categories". N is the number of
-entries in data/repos.yaml; M is the number of `###` category tables in the
+The intro pitch states "<N> entries organized into <M> catalog sections". N is
+the number of entries in data/repos.yaml; M is the number of `###` tables in the
 README's Curated catalog section. Run with no arguments to rewrite the README
 in place, or with --check (used by tests/CI) to fail if the numbers are stale.
 """
@@ -19,7 +19,9 @@ ROOT = Path(__file__).resolve().parents[1]
 README = ROOT / "README.md"
 REPOS_YAML = ROOT / "data" / "repos.yaml"
 
-COUNTS_PATTERN = re.compile(r"\d+ entries across \d+ categories")
+COUNTS_PATTERN = re.compile(
+    r"\d+ entries organized into \d+ catalog sections"
+)
 
 
 def expected_counts_phrase() -> str:
@@ -30,8 +32,8 @@ def expected_counts_phrase() -> str:
     )
     if not catalog_match:
         raise SystemExit("README.md has no '## Curated catalog' section")
-    categories = re.findall(r"^### ", catalog_match.group(1), re.MULTILINE)
-    return f"{len(entries)} entries across {len(categories)} categories"
+    sections = re.findall(r"^### ", catalog_match.group(1), re.MULTILINE)
+    return f"{len(entries)} entries organized into {len(sections)} catalog sections"
 
 
 def main() -> int:

--- a/tests/test_readme_counts.py
+++ b/tests/test_readme_counts.py
@@ -16,8 +16,17 @@ from scripts.sync_readme_counts import COUNTS_PATTERN, README, expected_counts_p
 def test_readme_intro_counts_match_catalog():
     phrase = expected_counts_phrase()
     found = COUNTS_PATTERN.findall(README.read_text())
-    assert found, "README.md lost its '<N> entries across <M> categories' phrase"
+    assert found, (
+        "README.md lost its "
+        "'<N> entries organized into <M> catalog sections' phrase"
+    )
     assert found == [phrase], (
         f"README counts {found} are stale, expected '{phrase}'. "
         "Run: python scripts/sync_readme_counts.py"
     )
+
+
+def test_counts_phrase_describes_readme_sections_not_yaml_categories():
+    phrase = expected_counts_phrase()
+    assert phrase.endswith("entries organized into 14 catalog sections")
+    assert COUNTS_PATTERN.fullmatch(phrase)


### PR DESCRIPTION
## Summary

Follow-up to #21 and issue #20.

- Shortens the README and moves the curated catalog closer to the top.
- Describes the catalog accurately as official-first and community-inclusive across MCP servers, agent skills, AI agents, frameworks, and supporting resources.
- Replaces ambiguous production-access and readiness language with the fields the catalog actually records.
- Narrows the CI audit claim to GitHub reachability and archived status, explicitly documenting that non-GitHub links and freshness require curator review.
- Clarifies that approval and maturity emoji are evidence summaries, not enforcement or production-readiness guarantees.
- Calls the 14 README groupings "catalog sections" so they are not confused with the 24 internal YAML category values.
- Enforces synchronized README counts during PR validation without attempting to push directly to protected `main`.

## Why

The previous wording implied that every entry was official, every link was automatically audited, action capability proved production access, and maturity labels guaranteed readiness. The catalog actually combines official and community-driven resources, and its automated audit only covers GitHub repository reachability and archived state.

## Validation

- [x] `.venv/bin/python3 scripts/validate_repos_yaml.py`
- [x] `.venv/bin/python3 scripts/sync_readme_counts.py --check`
- [x] `.venv/bin/python3 -m pytest -q` — 45 passed
- [x] `.venv/bin/python3 scripts/run_mock_eval_scenarios.py` — 7/7 passed
- [x] `.venv/bin/python3 scripts/audit_github_repos.py --workers 12` — 49 reachable, 10 non-GitHub entries skipped, 0 archived
- [x] `git diff --check`
