### PR TITLE
Add shieldly-io/cli (agent-scan) - AWS blast-radius scanner for AI agent credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated, **official-first** catalog of MCP servers, agent skills, AI agents, f
 
 Most agent lists stop at discovery. This one is built for operators:
 
-- **Official-first, community-inclusive** — 61 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
+- **Official-first, community-inclusive** — 62 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
 - **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
 - **Audited by CI** — GitHub repository entries are checked weekly for reachability and archived status; non-GitHub documentation links are outside this automated check and require curator review.
 - **Installable, not just readable** — [one command](#install-official-skills-into-your-coding-agent) installs hundreds of official skills from cataloged Google, Microsoft, Azure, and Azure DevOps sources into Claude Code, Cursor, Codex, VS Code, or Antigravity.
@@ -130,6 +130,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines 
 | [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top-10/) | 🟢 🔵 🛡️ 📊 | Official OWASP MCP Top 10 documentation for assessing Model Context Protocol security risks across agentic DevOps integrations. |
 | [Snyk Studio MCP docs](https://docs.snyk.io/evo-by-snyk/agentic-security-with-snyk-studio/getting-started-with-snyk-studio) | 🟢 🔵 🛡️ 📊 | Official Snyk documentation for Snyk Studio agentic security workflows and Snyk MCP Server usage. |
 | [snyk/agent-scan](https://github.com/snyk/agent-scan) | 🟢 🛡️ 📊 | Official Snyk security scanner for AI agents, MCP servers, and agent skills. |
+| [shieldly-io/cli](https://github.com/shieldly-io/cli) | 🟢 🛡️ 📊 | Official Shieldly agent-scan CLI that grades the AWS blast radius of AI agent credentials; offline by default, SARIF output, CI budget enforcement. |
 | [Wiz WIN MCP Server docs](https://docs.wiz.io/dev/win-mcp-server) | 🟢 🔵 🛡️ 📊 | Official Wiz documentation for the WIN MCP server, adding CNAPP and cloud-security coverage. |
 
 ### Official CI/CD and GitOps MCP Servers

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -821,6 +821,28 @@
     - 🛡️
     - 📊
 
+- name: shieldly-io/cli
+  url: https://github.com/shieldly-io/cli
+  category: official-agent-security-tools
+  type: agent-security-scanner
+  framework: security-scanner
+  primary_language: JavaScript
+  cloud_provider: aws
+  use_cases:
+    - ai-agent-aws-permission-review
+    - agent-credential-blast-radius-analysis
+    - least-privilege-policy-generation
+  action_level: read-only
+  human_approval: true
+  evidence_tracing: "yes"
+  maturity: production-adjacent
+  risk_notes: "Scan reads local agent configs and AWS policies; findings are advisory and need human review before tightening production IAM policies. Offline by default; optional upload sends results to Shieldly's SaaS."
+  operator_note: "Official Shieldly CLI (agent-scan) that grades the AWS blast radius of AI agent credentials — destructive, exfiltration, privilege-escalation, and unbounded-cost actions — from auto-discovered agent/MCP configs, a policy file, role ARN, or CloudFormation template; SARIF output and CI budget enforcement."
+  labels:
+    - 🟢
+    - 🛡️
+    - 📊
+
 - name: Wiz WIN MCP Server docs
   url: https://docs.wiz.io/dev/win-mcp-server
   category: official-cloud-security-mcp-servers

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -38,7 +38,7 @@ def valid_entry(**overrides):
 def test_validates_seed_data_file():
     entries = validate_file(Path("data/repos.yaml"))
 
-    assert len(entries) == 61
+    assert len(entries) == 62
     assert all(field in entries[0] for field in REQUIRED_FIELDS)
 
 


### PR DESCRIPTION
Adds Shieldly agent-scan to the Official Security and Code-Quality section, alongside snyk/agent-scan which covers the complementary angle (it scans the agent/tool itself; agent-scan grades what the agent's AWS credentials could do).

**Operational use case:** before wiring AWS credentials into a Claude Code / Cursor / Windsurf / MCP setup, run `npx @shieldly/cli agent-scan` to see what those credentials could destroy, exfiltrate, escalate to, or spend. Auto-discovers agent configs (.mcp.json, Claude Code/Desktop, Cursor, Windsurf, VS Code) or takes --policy-file / --role-arn / --profile / --cfn-file.

**Action level:** read-only (analysis only; the --fix least-privilege generator writes a proposed policy file locally, never touches AWS).
**Safety/approval model:** offline by default, nothing leaves the machine unless --upload is passed; findings are advisory and need human review.
**Evidence:** SARIF output for the GitHub Security tab, JSON reports, CI budget-file enforcement. Docs: https://www.shieldly.io/docs/agent-scan
**Evaluable without cloud credentials:** yes — point it at any policy JSON or CloudFormation template.
**Commercial disclosure:** the CLI scan, SARIF/budget CI mode, and fix generator are free; scan history/diffs and Slack alerts are part of Shieldly's paid SaaS plans.

Ran the full local validation per CONTRIBUTING (validate_repos_yaml, sync_readme_counts, pytest 45 passed, run_mock_eval_scenarios); bumped the seed-data count test 61→62.

Disclosure: I build Shieldly.