### PR TITLE
feat: add Flux Operator MCP server to official GitOps catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated, **official-first** catalog of MCP servers, agent skills, AI agents, f
 
 Most agent lists stop at discovery. This one is built for operators:
 
-- **Official-first, community-inclusive** — 61 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
+- **Official-first, community-inclusive** — 62 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
 - **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
 - **Audited by CI** — GitHub repository entries are checked weekly for reachability and archived status; non-GitHub documentation links are outside this automated check and require curator review.
 - **Installable, not just readable** — [one command](#install-official-skills-into-your-coding-agent) installs hundreds of official skills from cataloged Google, Microsoft, Azure, and Azure DevOps sources into Claude Code, Cursor, Codex, VS Code, or Antigravity.
@@ -138,6 +138,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines 
 | --- | --- | --- |
 | [jenkinsci/mcp-server-plugin](https://github.com/jenkinsci/mcp-server-plugin) | 🟢 🔵 🛡️ ⚠️ | Official Jenkins plugin that enables Jenkins to act as an MCP server for LLM-powered clients. |
 | [argoproj-labs/mcp-for-argocd](https://github.com/argoproj-labs/mcp-for-argocd) | 🟡 🔵 🛡️ ⚠️ | Argo Project Labs MCP server implementation for Argo CD, filling the GitOps/CD gap in the catalog. |
+| [controlplaneio-fluxcd/flux-operator (MCP)](https://github.com/controlplaneio-fluxcd/flux-operator/tree/main/cmd/mcp) | 🟢 🔵 🛡️ 📊 ⚠️ | Official Flux Operator MCP server from CNCF Flux core maintainers; Go single-binary with read-only mode, kubeconfig scoping, and Kubernetes impersonation. Covers Kustomizations, HelmReleases, drift detection, root cause analysis, and multi-cluster comparison. |
 | [CircleCI-Public/mcp-server-circleci](https://github.com/CircleCI-Public/mcp-server-circleci) | 🟢 🔵 🛡️ 📊 | Official CircleCI MCP server for build failure logs, pipeline status, flaky test detection, and usage analysis. |
 | [harness/mcp-server](https://github.com/harness/mcp-server) | 🟢 🔵 🛡️ ⚠️ | Official Harness MCP server (Go) for CI/CD pipelines, deployments, connectors, feature flags, and infrastructure operations; risk-tiered model blocks destructive ops without confirmation. |
 

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -776,6 +776,31 @@
     - 🛡️
     - ⚠️
 
+- name: controlplaneio-fluxcd/flux-operator (MCP)
+  url: https://github.com/controlplaneio-fluxcd/flux-operator/tree/main/cmd/mcp
+  category: official-gitops-mcp-servers
+  type: mcp-server
+  framework: MCP + Flux CD
+  primary_language: Go
+  cloud_provider: multi-cloud
+  use_cases:
+    - gitops-pipeline-debugging
+    - flux-kustomization-management
+    - kubernetes-drift-detection
+    - multi-cluster-gitops-operations
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: "yes"
+  maturity: production-adjacent
+  risk_notes: "Flux MCP can trigger reconciliations, suspend/resume Flux resources, and interact with live Kubernetes clusters via kubeconfig; use read-only mode (--read-only=true) for observation-only sessions and scope kubeconfig RBAC to least privilege."
+  operator_note: "Official Flux Operator MCP server from CNCF Flux core maintainers at ControlPlane; Go single-binary with read-only mode, kubeconfig scoping, and Kubernetes impersonation support. Covers Kustomizations, HelmReleases, drift detection, root cause analysis, and multi-cluster comparison."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - 📊
+    - ⚠️
+
 - name: Snyk Studio MCP docs
   url: https://docs.snyk.io/evo-by-snyk/agentic-security-with-snyk-studio/getting-started-with-snyk-studio
   category: official-security-mcp-servers

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -38,7 +38,7 @@ def valid_entry(**overrides):
 def test_validates_seed_data_file():
     entries = validate_file(Path("data/repos.yaml"))
 
-    assert len(entries) == 61
+    assert len(entries) == 62
     assert all(field in entries[0] for field in REQUIRED_FIELDS)
 
 


### PR DESCRIPTION
## Summary

Adds the official **Flux Operator MCP server** from CNCF Flux core maintainers (ControlPlane) to the `official-gitops-mcp-servers` catalog category.

### What gap this fills

The GitOps category previously had only Argo CD (`argoproj-labs/mcp-for-argocd`). Flux CD is the other major CNCF-graduated GitOps toolkit and its MCP server is production-grade but was missing from the catalog.

### About the entry

- **GitHub**: [controlplaneio-fluxcd/flux-operator](https://github.com/controlplaneio-fluxcd/flux-operator/tree/main/cmd/mcp) (678 ⭐, active)
- **Vendor**: ControlPlane — CNCF Flux core maintainers
- **Language**: Go single-binary, statically compiled, no external deps
- **Install**: `brew install controlplaneio-fluxcd/tap/flux-operator-mcp`
- **Docs**: https://fluxcd.control-plane.io/mcp/

### Capabilities

- Debug GitOps pipelines from Flux resources to application logs
- Query Kustomizations, HelmReleases, and ResourceSets
- Multi-cluster comparison and drift detection
- Root cause analysis for failed deployments
- Suspend/resume Flux resources and trigger reconciliations

### Safety scoring

| Field | Value |
|---|---|
| action_level | write-capable |
| human_approval | true |
| evidence_tracing | yes |
| maturity | production-adjacent |

Safety features: read-only mode (`--read-only=true`), kubeconfig scoping, Kubernetes impersonation for least-privilege access, and secret masking.

### Sources verified

- Official blog post: https://fluxcd.io/blog/2025/05/ai-assisted-gitops
- MCP docs: https://fluxcd.control-plane.io/mcp/
- GitHub: controlplaneio-fluxcd/flux-operator (not archived, actively maintained)

## Changes

- `data/repos.yaml`: new entry (62 total entries)
- `README.md`: added to CI/CD and GitOps table; updated count line
- `tests/test_repos_yaml.py`: bump expected count from 61 → 62

## Validation

```
python3 scripts/validate_repos_yaml.py  →  Validation passed: 62 repo entries in data/repos.yaml
pytest -q  →  45 passed in 0.93s
```