### PR TITLE
Add control-theory/dstl8 to Official SRE MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated, **official-first** catalog of MCP servers, agent skills, AI agents, f
 
 Most agent lists stop at discovery. This one is built for operators:
 
-- **Official-first, community-inclusive** — 61 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
+- **Official-first, community-inclusive** — 62 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
 - **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
 - **Audited by CI** — GitHub repository entries are checked weekly for reachability and archived status; non-GitHub documentation links are outside this automated check and require curator review.
 - **Installable, not just readable** — [one command](#install-official-skills-into-your-coding-agent) installs hundreds of official skills from cataloged Google, Microsoft, Azure, and Azure DevOps sources into Claude Code, Cursor, Codex, VS Code, or Antigravity.
@@ -71,6 +71,7 @@ Pass `--dry-run` to preview first. Commands for Cursor, Codex, VS Code, Antigrav
 
 | Date | Entry | Category |
 | --- | --- | --- |
+| 2026-07-13 | [control-theory/dstl8](https://github.com/control-theory/dstl8) | SRE / observability |
 | 2026-07-12 | [harness/mcp-server](https://github.com/harness/mcp-server) | CI/CD / Harness |
 | 2026-07-12 | [harness/harness-skills](https://github.com/harness/harness-skills) | Agent skills / Harness |
 | 2026-07-09 | [redis/mcp-redis](https://github.com/redis/mcp-redis) | Data platform / Redis |
@@ -178,6 +179,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines 
 | [PagerDuty/pagerduty-mcp-server](https://github.com/PagerDuty/pagerduty-mcp-server) | 🟢 🔵 🛡️ ⚠️ | Official PagerDuty MCP server for incidents, services, schedules, event orchestrations, and embedded incident UIs. |
 | [newrelic/mcp-server](https://github.com/newrelic/mcp-server) | 🟢 🔵 🛡️ 📊 | Official New Relic MCP server for APM, dashboard, and NRQL-based observability context. |
 | [Elastic Agent Builder MCP server docs](https://www.elastic.co/docs/explore-analyze/ai-features/agent-builder/mcp-server) | 🟢 🔵 🛡️ 📊 | Official Elastic documentation for exposing Agent Builder tools through MCP with Kibana URL and API-key authentication. |
+| [control-theory/dstl8](https://github.com/control-theory/dstl8) | 🟢 🔵 🛡️ 📊 ⚠️ | Official Dstl8 CLI and per-org MCP server for incident investigation, log pattern and anomaly analysis, sentiment/severity context, and deploy verification across Kubernetes, AWS, Vercel, Supabase, and OpenTelemetry sources. |
 
 ### Official Agent Skills and Frameworks
 

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1384,3 +1384,27 @@
     - 🛡️
     - 📊
     - ⚠️
+- name: control-theory/dstl8
+  url: https://github.com/control-theory/dstl8
+  category: official-sre-mcp-servers
+  type: mcp-server
+  framework: MCP + skills + plugins
+  primary_language: Shell
+  cloud_provider: multi-cloud
+  use_cases:
+    - incident-investigation
+    - log-pattern-and-anomaly-analysis
+    - deploy-verification
+    - cross-environment-correlation
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: partial
+  maturity: production-adjacent
+  risk_notes: "Org-scoped API token exposes log telemetry that may contain sensitive data; write tools can create, update, and delete incidents, annotations, and knowledge-graph entries (not infrastructure). Token creation and account setup are human-driven; scope tokens per org and review write actions. Hosted commercial platform; the CLI, Claude Code plugin, and skill are public, the backend is not OSS."
+  operator_note: "Official Dstl8 CLI and per-org MCP server for incident investigation, log pattern and anomaly analysis, sentiment/severity context, and deploy verification across Kubernetes, AWS, Vercel, Supabase, and OpenTelemetry sources."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - 📊
+    - ⚠️

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -38,7 +38,7 @@ def valid_entry(**overrides):
 def test_validates_seed_data_file():
     entries = validate_file(Path("data/repos.yaml"))
 
-    assert len(entries) == 61
+    assert len(entries) == 62
     assert all(field in entries[0] for field in REQUIRED_FIELDS)
 
 


### PR DESCRIPTION
## Summary

Adds [control-theory/dstl8](https://github.com/control-theory/dstl8) — the official Dstl8 CLI and per-org MCP server — to the **Official SRE MCP Servers** section, plus a Recently added row. Dstl8 is an always-on log observability platform whose MCP server gives AI agents incident investigation, log pattern/anomaly analysis, sentiment/severity context, and deploy verification across Kubernetes, AWS, Vercel, Supabase, and OpenTelemetry sources.

Disclosure: I work on Dstl8 at ControlTheory. The entry follows the contribution rules — honest labels, `risk_notes` cover the write-capable tools (incidents/annotations/knowledge-graph, not infrastructure) and disclose that the hosted backend is commercial while the CLI, Claude Code plugin, and skill are public.

Also bumps the seed-count assertion in `tests/test_repos_yaml.py` from 61 to 62 to match.

## Entry checklist (skip if this PR doesn't add/change a catalog entry)

- [x] The repo URL is public and reachable.
- [x] The entry has a specific category.
- [x] The `risk_notes` field explains what could go wrong.
- [x] The `operator_note` field explains why an infrastructure operator should care.
- [x] Labels match the observed behavior, not marketing claims.
- [x] `data/repos.yaml` and `README.md` are both updated.

## Validation

```bash
python scripts/validate_repos_yaml.py
pytest -q
python scripts/run_mock_eval_scenarios.py
python scripts/audit_github_repos.py --workers 12 --fail-on-unreachable
```

- [x] All of the above pass locally. (62 entries validated; 45 tests pass; 7/7 mock evals; audit shows control-theory/dstl8 reachable with no warnings. `sync_readme_counts.py` was also run to refresh the intro counts.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)