### PR TITLE
feat: add dynatrace-oss/dynatrace-mcp to SRE observability catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated, **official-first** catalog of MCP servers, agent skills, AI agents, f
 
 Most agent lists stop at discovery. This one is built for operators:
 
-- **Official-first, community-inclusive** — 62 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
+- **Official-first, community-inclusive** — 63 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
 - **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
 - **Audited by CI** — GitHub repository entries are checked weekly for reachability and archived status; non-GitHub documentation links are outside this automated check and require curator review.
 - **Installable, not just readable** — [one command](#install-official-skills-into-your-coding-agent) installs hundreds of official skills from cataloged Google, Microsoft, Azure, and Azure DevOps sources into Claude Code, Cursor, Codex, VS Code, or Antigravity.
@@ -71,6 +71,7 @@ Pass `--dry-run` to preview first. Commands for Cursor, Codex, VS Code, Antigrav
 
 | Date | Entry | Category |
 | --- | --- | --- |
+| 2026-07-14 | [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) | SRE / Dynatrace observability |
 | 2026-07-12 | [harness/mcp-server](https://github.com/harness/mcp-server) | CI/CD / Harness |
 | 2026-07-12 | [harness/harness-skills](https://github.com/harness/harness-skills) | Agent skills / Harness |
 | 2026-07-09 | [redis/mcp-redis](https://github.com/redis/mcp-redis) | Data platform / Redis |
@@ -178,6 +179,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines 
 | [Splunk MCP Server](https://splunkbase.splunk.com/app/7931) | 🟢 🔵 🛡️ 📊 | Splunkbase listing for the Splunk-supported MCP Server for Splunk Platform, Enterprise, and Cloud customers. |
 | [PagerDuty/pagerduty-mcp-server](https://github.com/PagerDuty/pagerduty-mcp-server) | 🟢 🔵 🛡️ ⚠️ | Official PagerDuty MCP server for incidents, services, schedules, event orchestrations, and embedded incident UIs. |
 | [newrelic/mcp-server](https://github.com/newrelic/mcp-server) | 🟢 🔵 🛡️ 📊 | Official New Relic MCP server for APM, dashboard, and NRQL-based observability context. |
+| [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) | 🟢 🔵 🛡️ 📊 ⚠️ | Official Dynatrace open-source MCP server for DQL querying, anomaly/incident/Kubernetes investigation, Davis Copilot AI chat, and deployment automation. |
 | [Elastic Agent Builder MCP server docs](https://www.elastic.co/docs/explore-analyze/ai-features/agent-builder/mcp-server) | 🟢 🔵 🛡️ 📊 | Official Elastic documentation for exposing Agent Builder tools through MCP with Kibana URL and API-key authentication. |
 
 ### Official Agent Skills and Frameworks

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1134,6 +1134,32 @@
     - 🛡️
     - 📊
 
+- name: dynatrace-oss/dynatrace-mcp
+  url: https://github.com/dynatrace-oss/dynatrace-mcp
+  category: official-sre-mcp-servers
+  type: mcp-server
+  framework: MCP
+  primary_language: TypeScript
+  cloud_provider: multi-cloud
+  use_cases:
+    - dynatrace-observability-querying
+    - incident-and-anomaly-investigation
+    - natural-language-dql-generation
+    - deployment-health-gates
+    - security-vulnerability-tracking
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: "yes"
+  maturity: production-adjacent
+  risk_notes: "Automation tools can send Slack messages, emails, and create Dynatrace notebooks; DQL queries against Grail may incur consumption costs; scope Platform Token to least-privilege scopes and require approval before write/notification actions. Community-backed under dynatrace-oss; in maintenance mode — prefer the official Dynatrace-hosted MCP for new deployments."
+  operator_note: "Official Dynatrace open-source MCP server (dynatrace-oss org) for Dynatrace SaaS observability: DQL querying, problem/vulnerability/Kubernetes event listing, Davis Copilot AI chat, and deployment automation. 131 stars; MIT license; npm package @dynatrace-oss/dynatrace-mcp-server."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - 📊
+    - ⚠️
+
 - name: Elastic Agent Builder MCP server docs
   url: https://www.elastic.co/docs/explore-analyze/ai-features/agent-builder/mcp-server
   category: official-sre-mcp-servers

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -38,7 +38,7 @@ def valid_entry(**overrides):
 def test_validates_seed_data_file():
     entries = validate_file(Path("data/repos.yaml"))
 
-    assert len(entries) == 62
+    assert len(entries) == 63
     assert all(field in entries[0] for field in REQUIRED_FIELDS)
 
 


### PR DESCRIPTION
## Summary

Add [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) to the **Official SRE MCP Servers** catalog section.

**What is it?**
Official Dynatrace open-source MCP server under the `dynatrace-oss` GitHub org. Published as npm package `@dynatrace-oss/dynatrace-mcp-server`, with an official Dynatrace platform landing page (https://www.dynatrace.com/platform/mcp-server/) updated 2026-07-08.

**Capabilities (key tools):**
- `execute_dql` / `generate_dql_from_natural_language` / `verify_dql` — Grail data querying
- `list_problems` / `list_vulnerabilities` / `list_exceptions` / `get_kubernetes_events` — observability & SRE
- `chat_with_davis_copilot` / `execute_davis_analyzer` — AI-powered investigation
- `send_slack_message` / `send_email` / `send_event` — automation & notifications
- `create_dynatrace_notebook` — evidence sharing

**Metrics:** 131 stars, 25 forks, MIT license, TypeScript, active releases.

**Safety posture:**
- Requires scoped Platform Token (or OAuth client) — no credential embedding
- DQL Grail queries may incur consumption costs; budget guard via `DT_GRAIL_QUERY_BUDGET_GB`
- Write/notification tools require human approval
- Repo is in maintenance mode — official Dynatrace-hosted MCP recommended for new enterprise deployments

**Scoring:** write-capable / human_approval=true / evidence_tracing=yes / maturity=production-adjacent

## Changed files

| File | Change |
| --- | --- |
| `data/repos.yaml` | New `official-sre-mcp-servers` entry (63 total) |
| `README.md` | Row in Official SRE MCP Servers table + Recently added 2026-07-14 |
| `tests/test_repos_yaml.py` | Bump expected count 62 → 63 |
| README intro phrase | Auto-synced to '63 entries organized into 14 catalog sections' |

## Validation

```
python3 scripts/validate_repos_yaml.py
→ Validation passed: 63 repo entries in data/repos.yaml

python scripts/sync_readme_counts.py
→ README counts updated: 63 entries organized into 14 catalog sections

python -m pytest -q
→ 45 passed in 0.77s
```

## Notes

- `dynatrace-oss` is Dynatrace's official open-source org; the repo is community-backed but vendor-published with an official product page
- The separate `dynatrace-oss/dynatrace-managed-mcp` (self-hosted Dynatrace Managed) is a follow-on candidate for the catalog
