### PR TITLE
fix: remove brittle entry-count assertion and commit CVE patches for ADK agents

### DIFF
--- a/agents/adk/terraform-drift-detector/requirements.txt
+++ b/agents/adk/terraform-drift-detector/requirements.txt
@@ -1,3 +1,5 @@
 google-adk
 python-dotenv
 pydantic
+idna>=3.15
+python-multipart>=0.0.31

--- a/agents/adk/terraform-plan-reviewer/requirements.txt
+++ b/agents/adk/terraform-plan-reviewer/requirements.txt
@@ -1,3 +1,5 @@
 google-adk
 python-dotenv
 pydantic
+idna>=3.15
+python-multipart>=0.0.31

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -38,7 +38,8 @@ def valid_entry(**overrides):
 def test_validates_seed_data_file():
     entries = validate_file(Path("data/repos.yaml"))
 
-    assert len(entries) == 63
+    # Lower-bound check: catalog grows over time; avoid brittle equality.
+    assert len(entries) >= 63
     assert all(field in entries[0] for field in REQUIRED_FIELDS)
 
 


### PR DESCRIPTION
## Summary

Daily maintainer run — 2026-07-15.

### Problem 1: brittle CI test

`tests/test_repos_yaml.py` had a hard-coded equality assertion:
```python
assert len(entries) == 63
```
Every time any new catalog entry is merged (which happens daily), this assertion breaks CI immediately. PRs #25, #28, #30 all caused this to fire or require manual edits.

**Fix:** Changed to a lower-bound assertion (`>= 63`). The existing `test_seed_data_has_unique_repo_names` test already guards against duplicates — no safety regression.

### Problem 2: uncommitted CVE patches

Two `requirements.txt` files for the ADK agent examples had pending local modifications that were never committed:
- `agents/adk/terraform-drift-detector/requirements.txt`
- `agents/adk/terraform-plan-reviewer/requirements.txt`

Added CVE patches:
- `idna>=3.15` (CVE fix for IDNA library)
- `python-multipart>=0.0.31` (CVE fix for multipart parsing)

## Validation

```
$ python3 scripts/validate_repos_yaml.py
Validation passed: 63 repo entries in data/repos.yaml

$ python3 -m pytest tests/ -q
.............................................
45 passed in 0.84s
```

## Risk

- Low. Pure test fix (no catalog data changed) + unopinionated CVE pin bumps.
- The count test can be raised again at any time if needed.