### PR TITLE
chore: configure Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/Chicago
+    groups:
+      non-breaking-updates:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/Chicago
+    groups:
+      non-breaking-updates:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: pip
+    directories:
+      - /agents/adk/terraform-drift-detector
+      - /agents/adk/terraform-plan-reviewer
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/Chicago
+    groups:
+      non-breaking-updates:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: terraform
+    directory: /agents/adk/terraform-plan-reviewer/terraform/gcs-sample
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/Chicago
+    groups:
+      non-breaking-updates:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
       time: "06:00"
       timezone: America/Chicago
     groups:
@@ -19,8 +18,7 @@ updates:
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
       time: "06:00"
       timezone: America/Chicago
     groups:
@@ -36,8 +34,7 @@ updates:
       - /agents/adk/terraform-drift-detector
       - /agents/adk/terraform-plan-reviewer
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
       time: "06:00"
       timezone: America/Chicago
     groups:
@@ -51,8 +48,7 @@ updates:
   - package-ecosystem: terraform
     directory: /agents/adk/terraform-plan-reviewer/terraform/gcs-sample
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
       time: "06:00"
       timezone: America/Chicago
     groups:


### PR DESCRIPTION
## Summary

- add daily Dependabot checks for GitHub Actions
- monitor the root Python project and both ADK agent requirements directories
- monitor the Terraform GCS sample
- group minor and patch updates while keeping major upgrades separate for review

## Test plan

- [x] Parse `.github/dependabot.yml` with PyYAML and verify all schedules are daily
- [x] `.venv/bin/python3 scripts/validate_repos_yaml.py`
- [x] `.venv/bin/python3 -m pytest -q`
- [x] `.venv/bin/python3 scripts/run_mock_eval_scenarios.py`
- [x] `.venv/bin/python3 scripts/audit_github_repos.py --workers 12`
- [x] `git diff --cached --check`