### PR TITLE
feat: add Alibaba Cloud agent toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated, **official-first** catalog of MCP servers, agent skills, AI agents, f
 
 Most agent lists stop at discovery. This one is built for operators:
 
-- **Official-first, community-inclusive** — 66 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
+- **Official-first, community-inclusive** — 67 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
 - **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
 - **Audited by CI** — GitHub repository entries are checked weekly for reachability and archived status; non-GitHub documentation links are outside this automated check and require curator review.
 - **Installable, not just readable** — [one command](#install-skills-into-your-coding-agent) installs hundreds of skills from cataloged Google, Microsoft, Azure, Azure DevOps, and Harness sources — plus a separate community set — into Claude Code, Cursor, Codex, VS Code, or Antigravity.
@@ -51,6 +51,7 @@ At minimum, record an explicit approval before any write-capable agent mutates i
 | Use case | Start with | Why |
 | --- | --- | --- |
 | AWS agentic cloud automation | [aws/agent-toolkit-for-aws](https://github.com/aws/agent-toolkit-for-aws) | Official AWS-supported MCP, skills, plugins, project rules, IAM-aware controls, CloudWatch metrics, and CloudTrail auditability. |
+| Alibaba Cloud automation | [aliyun/alibabacloud-agent-toolkit](https://github.com/aliyun/alibabacloud-agent-toolkit) | Official Alibaba Cloud toolkit with MCP configuration, skills, plugins, rules, OpenAPI SDK code generation, Terraform/IaC Service operations, and local audit traces. |
 | Azure cloud automation | [microsoft/mcp](https://github.com/microsoft/mcp)<br>[microsoft/azure-skills](https://github.com/microsoft/azure-skills) | Official Microsoft MCP and skills/plugin sources for Azure resource workflows. |
 | Google Cloud automation | [google/mcp](https://github.com/google/mcp)<br>[googleapis/gcloud-mcp](https://github.com/googleapis/gcloud-mcp)<br>[google/skills](https://github.com/google/skills) | Official Google MCP and skills sources for GCP, Cloud Run, GKE, observability, and storage workflows. |
 | Source-control DevOps | [github/github-mcp-server](https://github.com/github/github-mcp-server)<br>[GitLab MCP server](https://docs.gitlab.com/user/gitlab_duo/model_context_protocol/mcp_server/)<br>[atlassian/atlassian-mcp-server](https://github.com/atlassian/atlassian-mcp-server) | Official MCP tool surfaces for repos, issues, PRs, Jira, Bitbucket, and related delivery workflows. |
@@ -80,6 +81,7 @@ Pass `--dry-run` to preview first. Commands for Cursor, Codex, VS Code, Antigrav
 
 | Date | Entry | Category |
 | --- | --- | --- |
+| 2026-07-21 | [aliyun/alibabacloud-agent-toolkit](https://github.com/aliyun/alibabacloud-agent-toolkit) | Cloud agent toolkit / Alibaba Cloud |
 | 2026-07-18 | [DopplerHQ/mcp-server](https://github.com/DopplerHQ/mcp-server) | Security / Doppler secrets management |
 | 2026-07-17 | [CrowdStrike/falcon-mcp](https://github.com/CrowdStrike/falcon-mcp) | Security / CrowdStrike Falcon SOC automation |
 | 2026-07-14 | [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) | SRE / Dynatrace observability |
@@ -114,6 +116,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines 
 | Repo | Labels | Operator note |
 | --- | --- | --- |
 | [aws/agent-toolkit-for-aws](https://github.com/aws/agent-toolkit-for-aws) | 🟢 🔵 🛡️ 📊 ⚠️ | Official AWS-supported toolkit with managed MCP server access, current AWS docs/API knowledge tools, on-demand agent skills, Claude Code/Codex plugins, and project rules for Kiro, Claude Code, Cursor, Codex, and other MCP-compatible agents. |
+| [aliyun/alibabacloud-agent-toolkit](https://github.com/aliyun/alibabacloud-agent-toolkit) | 🟡 🔵 🛡️ 📊 ⚠️ | Official Alibaba Cloud toolkit with MCP configuration, skills, plugins, rules, OpenAPI SDK code generation, Terraform/IaC Service operations, remote telemetry controls, and local JSONL audit traces. |
 | [awslabs/mcp](https://github.com/awslabs/mcp) | 🟢 🔵 🛡️ ⚠️ | Official AWS Labs MCP server collection; useful legacy/source reference while AWS transitions capabilities into Agent Toolkit. |
 | [microsoft/mcp](https://github.com/microsoft/mcp) | 🟢 🔵 🛡️ ⚠️ | Official Microsoft MCP catalog, including Azure cloud and infrastructure MCP references. |
 | [google/mcp](https://github.com/google/mcp) | 🟢 🔵 🛡️ ⚠️ | Official Google MCP repository listing managed and open-source MCP servers for Google and Google Cloud. |

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -24,6 +24,32 @@
     - 📊
     - ⚠️
 
+- name: aliyun/alibabacloud-agent-toolkit
+  url: https://github.com/aliyun/alibabacloud-agent-toolkit
+  category: official-cloud-agent-toolkits
+  type: agent-toolkit
+  framework: MCP + skills + plugins + rules
+  primary_language: unknown
+  cloud_provider: Alibaba Cloud
+  use_cases:
+    - alibaba-cloud-automation
+    - openapi-sdk-codegen
+    - terraform-iac-service-ops
+    - agent-skills
+    - local-audit-tracing
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: "yes"
+  maturity: prototype
+  risk_notes: "Can guide authenticated Alibaba Cloud OpenAPI and IaC Service workflows; remote telemetry is enabled by default and local traces can include prompts and tool I/O, so use least-privilege RAM credentials, disable telemetry if required, and require explicit approval before mutations."
+  operator_note: "Official Alibaba Cloud toolkit with MCP configuration, skills, plugins, rules, OpenAPI SDK code generation, Terraform/IaC Service operations, remote telemetry controls, and local JSONL audit traces."
+  labels:
+    - 🟡
+    - 🔵
+    - 🛡️
+    - 📊
+    - ⚠️
+
 - name: awslabs/mcp
   url: https://github.com/awslabs/mcp
   category: official-cloud-mcp-servers


### PR DESCRIPTION
## Summary

- Add official aliyun/alibabacloud-agent-toolkit to the cloud agent toolkit catalog.
- Document operator safety notes for write-capable Alibaba Cloud OpenAPI and IaC Service workflows.
- Update README top picks, recently added, and catalog count.

## Verification

- gh repo view aliyun/alibabacloud-agent-toolkit --json nameWithOwner,description,isArchived,pushedAt,defaultBranchRef,licenseInfo,url,repositoryTopics
- README fact check via gh api repos/aliyun/alibabacloud-agent-toolkit/contents/README.md
- python3 scripts/validate_repos_yaml.py
- python3 -m pytest -q (failed initially: no module named pytest)
- python3 -m venv .venv && . .venv/bin/activate && python -m pip install -e '.[dev]' && python -m pytest -q

Auto-generated by daily maintainer cron on 2026-07-21.