### PR TITLE
feat: import Archestra external catalog signals

### DIFF
--- a/data/external/README.md
+++ b/data/external/README.md
@@ -1,0 +1,32 @@
+# External catalog signals
+
+External MCP catalogs are useful radar, but their scores are not curator
+acceptance decisions. This directory stores generated sidecars that can enrich
+reviews without changing the safety-scored source of truth in `data/repos.yaml`.
+
+## Archestra signals
+
+`data/external/archestra-signals.json` is generated from a local clone of
+`archestra-ai/archestra`:
+
+```bash
+git clone --depth 1 https://github.com/archestra-ai/archestra.git /tmp/archestra
+python scripts/import_archestra_signals.py \
+  /tmp/archestra/mcp-catalog/data/mcp-evaluations
+```
+
+The generated file matches Archestra evaluation records to this catalog by
+GitHub URL or remote MCP URL and records:
+
+- external quality score;
+- protocol feature booleans;
+- local vs remote server type;
+- sensitive and required sensitive config fields;
+- OAuth presence;
+- selected GitHub metadata from the external evaluation.
+
+## Review rule
+
+Use external signals as review prompts only. Before adding or changing a catalog
+entry, still verify official ownership, freshness, action level, human approval,
+evidence tracing, credential behavior, and blast radius from first-party sources.

--- a/data/external/archestra-signals.json
+++ b/data/external/archestra-signals.json
@@ -1,0 +1,324 @@
+{
+  "generated_by": "scripts/import_archestra_signals.py",
+  "matched_entry_count": 10,
+  "schema_version": 1,
+  "signals": {
+    "CircleCI-Public/mcp-server-circleci": {
+      "archestra_name": "circleci-public__mcp-server-circleci",
+      "category": "AI Tools",
+      "description": "A specialized server implementation for the Model Context Protocol (MCP) designed to integrate with CircleCI's development workflow. This project serves as a bridge between CircleCI's infrastructure and the Model Context Protocol, enabling enhanced AI-powered development experiences.",
+      "display_name": "mcp-server-circleci",
+      "github_info": {
+        "ci_cd": false,
+        "contributors": 18,
+        "latest_commit_hash": "070d7e708c40ae18308a1719b623b2dfdc6535dd",
+        "releases": false,
+        "stars": 63,
+        "url": "https://github.com/CircleCI-Public/mcp-server-circleci"
+      },
+      "last_scraped_at": "2025-09-09T13:05:35.707Z",
+      "oauth_configured": false,
+      "programming_language": "TypeScript",
+      "protocol_features": {
+        "implementing_logging": false,
+        "implementing_oauth2": false,
+        "implementing_prompts": false,
+        "implementing_resources": true,
+        "implementing_roots": false,
+        "implementing_sampling": true,
+        "implementing_stdio": true,
+        "implementing_streamable_http": true,
+        "implementing_tools": true
+      },
+      "quality_score": 69,
+      "required_sensitive_config_fields": [
+        "circleci_token"
+      ],
+      "sensitive_config_fields": [
+        "circleci_token"
+      ],
+      "server_type": "local"
+    },
+    "Linear MCP server docs": {
+      "archestra_name": "linear__remote-mcp",
+      "category": "Development",
+      "description": "Remote MCP server for Linear - issue tracking and project management",
+      "display_name": "Linear",
+      "docs_url": "https://linear.app/docs/mcp",
+      "last_scraped_at": "2025-09-05T19:30:23.066Z",
+      "oauth_configured": true,
+      "programming_language": null,
+      "protocol_features": {},
+      "quality_score": 80,
+      "remote_url": "https://mcp.linear.app/mcp",
+      "required_sensitive_config_fields": [],
+      "sensitive_config_fields": [],
+      "server_type": "remote"
+    },
+    "argoproj-labs/mcp-for-argocd": {
+      "archestra_name": "argoproj-labs__mcp-for-argocd",
+      "category": "Development",
+      "description": "A Model Context Protocol (MCP) server that provides AI assistants with access to ArgoCD for GitOps continuous delivery. Manage applications, sync status, and deployment operations through the ArgoCD API.",
+      "display_name": "ArgoCD",
+      "github_info": {
+        "ci_cd": false,
+        "contributors": 0,
+        "latest_commit_hash": "",
+        "releases": false,
+        "stars": 0,
+        "url": "https://github.com/argoproj-labs/mcp-for-argocd"
+      },
+      "last_scraped_at": "2025-12-11T00:00:00.000Z",
+      "oauth_configured": false,
+      "programming_language": "TypeScript",
+      "protocol_features": {
+        "implementing_logging": true,
+        "implementing_oauth2": false,
+        "implementing_prompts": false,
+        "implementing_resources": true,
+        "implementing_roots": false,
+        "implementing_sampling": false,
+        "implementing_stdio": true,
+        "implementing_streamable_http": false,
+        "implementing_tools": true
+      },
+      "quality_score": 0,
+      "required_sensitive_config_fields": [
+        "ARGOCD_API_TOKEN"
+      ],
+      "sensitive_config_fields": [
+        "ARGOCD_API_TOKEN"
+      ],
+      "server_type": "local"
+    },
+    "awslabs/mcp": {
+      "archestra_name": "awslabs__mcp",
+      "category": "Development",
+      "description": "AWS MCP Servers — helping you get the most out of AWS, wherever you use MCP.",
+      "display_name": "mcp",
+      "github_info": {
+        "ci_cd": true,
+        "contributors": 128,
+        "latest_commit_hash": "35c319931c9123084ae998a258cc9e14cfcd50a6",
+        "releases": true,
+        "stars": 5175,
+        "url": "https://github.com/awslabs/mcp"
+      },
+      "last_scraped_at": "2025-09-09T13:06:54.610Z",
+      "oauth_configured": false,
+      "programming_language": "Python",
+      "protocol_features": {
+        "implementing_logging": false,
+        "implementing_oauth2": false,
+        "implementing_prompts": false,
+        "implementing_resources": true,
+        "implementing_roots": false,
+        "implementing_sampling": false,
+        "implementing_stdio": false,
+        "implementing_streamable_http": false,
+        "implementing_tools": true
+      },
+      "quality_score": 62,
+      "required_sensitive_config_fields": [],
+      "sensitive_config_fields": [],
+      "server_type": "local"
+    },
+    "cloudflare/mcp-server-cloudflare": {
+      "archestra_name": "cloudflare__mcp-server-cloudflare",
+      "category": "Cloud",
+      "description": "MCP server from cloudflare/mcp-server-cloudflare",
+      "display_name": "mcp-server-cloudflare",
+      "github_info": {
+        "ci_cd": true,
+        "contributors": 29,
+        "latest_commit_hash": "4267fd7fa9d94565382bcb6229fdd6d7f8f25d9d",
+        "releases": true,
+        "stars": 2922,
+        "url": "https://github.com/cloudflare/mcp-server-cloudflare"
+      },
+      "last_scraped_at": "2025-09-09T13:05:15.797Z",
+      "oauth_configured": false,
+      "programming_language": "TypeScript",
+      "protocol_features": {
+        "implementing_logging": false,
+        "implementing_oauth2": false,
+        "implementing_prompts": false,
+        "implementing_resources": true,
+        "implementing_roots": false,
+        "implementing_sampling": false,
+        "implementing_stdio": true,
+        "implementing_streamable_http": true,
+        "implementing_tools": true
+      },
+      "quality_score": 78,
+      "required_sensitive_config_fields": [
+        "cloudflare_api_token"
+      ],
+      "sensitive_config_fields": [
+        "cloudflare_api_token"
+      ],
+      "server_type": "local"
+    },
+    "github/github-mcp-server": {
+      "archestra_name": "githubcopilot__remote-mcp",
+      "category": "Development",
+      "description": "Remote MCP server for github - issue tracking and project management",
+      "display_name": "GitHub",
+      "docs_url": "https://github.com/github/github-mcp-server/blob/main/docs/remote-server.md",
+      "last_scraped_at": "2025-09-05T19:30:23.066Z",
+      "oauth_configured": true,
+      "programming_language": null,
+      "protocol_features": {},
+      "quality_score": 80,
+      "remote_url": "https://api.githubcopilot.com/mcp/",
+      "required_sensitive_config_fields": [
+        "access_token"
+      ],
+      "sensitive_config_fields": [
+        "access_token"
+      ],
+      "server_type": "remote"
+    },
+    "grafana/mcp-grafana": {
+      "archestra_name": "grafana__mcp-grafana",
+      "category": "Monitoring",
+      "description": "MCP server for Grafana",
+      "display_name": "mcp-grafana",
+      "github_info": {
+        "ci_cd": true,
+        "contributors": 26,
+        "latest_commit_hash": "8c3f20f7fbc800737a0935d73ff618ecaa223a4e",
+        "releases": true,
+        "stars": 1320,
+        "url": "https://github.com/grafana/mcp-grafana"
+      },
+      "last_scraped_at": "2025-09-09T13:06:23.800Z",
+      "oauth_configured": false,
+      "programming_language": "Go",
+      "protocol_features": {
+        "implementing_logging": false,
+        "implementing_oauth2": false,
+        "implementing_prompts": false,
+        "implementing_resources": true,
+        "implementing_roots": false,
+        "implementing_sampling": false,
+        "implementing_stdio": false,
+        "implementing_streamable_http": true,
+        "implementing_tools": true
+      },
+      "quality_score": 64,
+      "required_sensitive_config_fields": [],
+      "sensitive_config_fields": [
+        "grafana_password",
+        "grafana_service_account_token"
+      ],
+      "server_type": "local"
+    },
+    "modelcontextprotocol/servers": {
+      "archestra_name": "modelcontextprotocol__servers__src__sqlite",
+      "category": null,
+      "description": "Model Context Protocol Servers",
+      "display_name": "sqlite",
+      "github_info": {
+        "ci_cd": true,
+        "contributors": 30,
+        "latest_commit_hash": "8023ca60b32d7f06dddce77239606ce6c40725ad",
+        "releases": true,
+        "stars": 62134,
+        "url": "https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite"
+      },
+      "last_scraped_at": "2025-07-30T22:31:41.937Z",
+      "oauth_configured": false,
+      "programming_language": "TypeScript",
+      "protocol_features": {
+        "implementing_logging": false,
+        "implementing_oauth2": false,
+        "implementing_prompts": false,
+        "implementing_resources": false,
+        "implementing_roots": false,
+        "implementing_sampling": false,
+        "implementing_stdio": false,
+        "implementing_streamable_http": false,
+        "implementing_tools": false
+      },
+      "quality_score": 98,
+      "required_sensitive_config_fields": [],
+      "sensitive_config_fields": [],
+      "server_type": "local"
+    },
+    "mongodb-js/mongodb-mcp-server": {
+      "archestra_name": "mongodb-js__mongodb-mcp-server",
+      "category": "Data",
+      "description": "Official MongoDB MCP server that enables AI assistants to interact with MongoDB databases and Atlas deployments. Supports CRUD operations, aggregation pipelines, collection management, indexing, and Atlas cluster administration.",
+      "display_name": "MongoDB",
+      "github_info": {
+        "ci_cd": true,
+        "contributors": 1,
+        "latest_commit_hash": null,
+        "releases": true,
+        "stars": 0,
+        "url": "https://github.com/mongodb-js/mongodb-mcp-server"
+      },
+      "last_scraped_at": "2026-01-13T00:00:00.000Z",
+      "oauth_configured": false,
+      "programming_language": "TypeScript",
+      "protocol_features": {
+        "implementing_logging": false,
+        "implementing_oauth2": false,
+        "implementing_prompts": false,
+        "implementing_resources": true,
+        "implementing_roots": false,
+        "implementing_sampling": false,
+        "implementing_stdio": true,
+        "implementing_streamable_http": false,
+        "implementing_tools": true
+      },
+      "quality_score": 85,
+      "required_sensitive_config_fields": [
+        "connection_string"
+      ],
+      "sensitive_config_fields": [
+        "connection_string",
+        "tls_certificate_ca",
+        "tls_certificate_key"
+      ],
+      "server_type": "local"
+    },
+    "redis/mcp-redis": {
+      "archestra_name": "redis__mcp-redis",
+      "category": "AI Tools",
+      "description": "The official Redis MCP Server is a natural language interface designed for agentic applications to manage and search data in Redis efficiently",
+      "display_name": "mcp-redis",
+      "github_info": {
+        "ci_cd": true,
+        "contributors": 16,
+        "latest_commit_hash": "d892956f1e5fc85195d267062692a76d79b5314e",
+        "releases": true,
+        "stars": 231,
+        "url": "https://github.com/redis/mcp-redis"
+      },
+      "last_scraped_at": "2025-09-09T13:05:31.976Z",
+      "oauth_configured": false,
+      "programming_language": "Python",
+      "protocol_features": {
+        "implementing_logging": true,
+        "implementing_oauth2": false,
+        "implementing_prompts": false,
+        "implementing_resources": false,
+        "implementing_roots": false,
+        "implementing_sampling": false,
+        "implementing_stdio": true,
+        "implementing_streamable_http": false,
+        "implementing_tools": true
+      },
+      "quality_score": 65,
+      "required_sensitive_config_fields": [],
+      "sensitive_config_fields": [
+        "redis_pwd"
+      ],
+      "server_type": "local"
+    }
+  },
+  "source": "archestra-ai/archestra mcp-catalog/data/mcp-evaluations",
+  "source_files_seen": 904
+}

--- a/scripts/import_archestra_signals.py
+++ b/scripts/import_archestra_signals.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Import Archestra MCP evaluation signals for catalog entries.
+
+This script does not change curator scores in data/repos.yaml. It reads an
+Archestra `mcp-catalog/data/mcp-evaluations` directory and writes a generated
+JSON sidecar with only matching entries. The sidecar is useful for discovery,
+search, and review, while keeping external quality scores separate from this
+repo's operator safety model.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+REPOS_YAML = ROOT / "data" / "repos.yaml"
+DEFAULT_OUTPUT = ROOT / "data" / "external" / "archestra-signals.json"
+
+
+def normalize_url(url: str) -> str:
+    value = url.strip().rstrip("/").lower()
+    if value.endswith(".git"):
+        value = value[: -len(".git")]
+    if value.startswith("http://"):
+        value = "https://" + value[len("http://") :]
+    return value
+
+
+def github_slug(url: str) -> str | None:
+    marker = "github.com/"
+    if marker not in url.lower():
+        return None
+    slug = normalize_url(url).split(marker, 1)[1]
+    parts = slug.split("/")
+    if len(parts) < 2:
+        return None
+    return "/".join(parts[:2])
+
+
+def load_catalog_index(path: Path = REPOS_YAML) -> dict[str, dict[str, Any]]:
+    entries = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(entries, list):
+        raise SystemExit(f"{path} must contain a list of entries")
+
+    index: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        url = str(entry.get("url", ""))
+        keys = {normalize_url(url)}
+        slug = github_slug(url)
+        if slug:
+            keys.add(slug)
+            keys.add(f"https://github.com/{slug}")
+        for key in keys:
+            index[key] = entry
+    return index
+
+
+def extract_signal(evaluation: dict[str, Any]) -> dict[str, Any]:
+    github_info = evaluation.get("github_info") or {}
+    protocol_features = evaluation.get("protocol_features") or {}
+    user_config = evaluation.get("user_config") or {}
+    oauth_config = evaluation.get("oauth_config") or None
+    server = evaluation.get("server") or {}
+
+    sensitive_fields = []
+    required_sensitive_fields = []
+    for name, config in user_config.items():
+        if not isinstance(config, dict) or not config.get("sensitive"):
+            continue
+        sensitive_fields.append(name)
+        if config.get("required"):
+            required_sensitive_fields.append(name)
+
+    signal: dict[str, Any] = {
+        "archestra_name": evaluation.get("name"),
+        "display_name": evaluation.get("display_name"),
+        "description": evaluation.get("description"),
+        "category": evaluation.get("category"),
+        "quality_score": evaluation.get("quality_score"),
+        "programming_language": evaluation.get("programming_language"),
+        "server_type": server.get("type"),
+        "protocol_features": protocol_features,
+        "sensitive_config_fields": sorted(sensitive_fields),
+        "required_sensitive_config_fields": sorted(required_sensitive_fields),
+        "oauth_configured": bool(oauth_config),
+        "last_scraped_at": evaluation.get("last_scraped_at"),
+    }
+    if github_info:
+        signal["github_info"] = {
+            "url": github_info.get("url"),
+            "stars": github_info.get("stars"),
+            "contributors": github_info.get("contributors"),
+            "releases": github_info.get("releases"),
+            "ci_cd": github_info.get("ci_cd"),
+            "latest_commit_hash": github_info.get("latest_commit_hash"),
+        }
+    remote_url = server.get("url")
+    if remote_url:
+        signal["remote_url"] = remote_url
+    docs_url = server.get("docs_url")
+    if docs_url:
+        signal["docs_url"] = docs_url
+    return signal
+
+
+def candidate_keys(evaluation: dict[str, Any]) -> set[str]:
+    keys: set[str] = set()
+    github_url = ((evaluation.get("github_info") or {}).get("url") or "")
+    server = evaluation.get("server") or {}
+    for url in [github_url, server.get("url", ""), server.get("docs_url", "")]:
+        if not url:
+            continue
+        keys.add(normalize_url(str(url)))
+        slug = github_slug(str(url))
+        if slug:
+            keys.add(slug)
+            keys.add(f"https://github.com/{slug}")
+    return keys
+
+
+def build_signals(source_dir: Path, catalog_path: Path = REPOS_YAML) -> dict[str, Any]:
+    if not source_dir.exists():
+        raise SystemExit(f"Archestra evaluation directory not found: {source_dir}")
+    catalog_index = load_catalog_index(catalog_path)
+    matches: dict[str, dict[str, Any]] = {}
+    files_seen = 0
+
+    for path in sorted(source_dir.glob("*.json")):
+        files_seen += 1
+        evaluation = json.loads(path.read_text(encoding="utf-8"))
+        for key in candidate_keys(evaluation):
+            entry = catalog_index.get(key)
+            if not entry:
+                continue
+            name = str(entry["name"])
+            matches[name] = extract_signal(evaluation)
+            break
+
+    return {
+        "schema_version": 1,
+        "source": "archestra-ai/archestra mcp-catalog/data/mcp-evaluations",
+        "generated_by": "scripts/import_archestra_signals.py",
+        "source_files_seen": files_seen,
+        "matched_entry_count": len(matches),
+        "signals": dict(sorted(matches.items())),
+    }
+
+
+def render(data: dict[str, Any]) -> str:
+    return json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source_dir", type=Path, help="Path to Archestra mcp-evaluations directory")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT, help="Generated output path")
+    parser.add_argument("--check", action="store_true", help="fail if output is stale instead of writing")
+    args = parser.parse_args()
+
+    expected = render(build_signals(args.source_dir))
+    current = args.output.read_text(encoding="utf-8") if args.output.exists() else None
+    if current == expected:
+        print(f"{args.output} is in sync: {json.loads(expected)['matched_entry_count']} matches")
+        return 0
+    if args.check:
+        state = "missing" if current is None else "stale"
+        print(f"{args.output} is {state}; rerun scripts/import_archestra_signals.py")
+        return 1
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(expected, encoding="utf-8")
+    print(f"{args.output} updated: {json.loads(expected)['matched_entry_count']} matches")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_import_archestra_signals.py
+++ b/tests/test_import_archestra_signals.py
@@ -1,0 +1,101 @@
+"""Tests for importing Archestra external MCP evaluation signals."""
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.import_archestra_signals import (  # noqa: E402
+    build_signals,
+    github_slug,
+    normalize_url,
+)
+
+
+def test_normalize_url_handles_github_variants():
+    assert normalize_url("HTTP://github.com/Owner/Repo.git/") == "https://github.com/owner/repo"
+    assert github_slug("https://github.com/Owner/Repo/tree/main/path") == "owner/repo"
+
+
+def test_build_signals_matches_by_github_url(tmp_path):
+    catalog = tmp_path / "repos.yaml"
+    catalog.write_text(
+        yaml.safe_dump(
+            [
+                {
+                    "name": "example/tool",
+                    "url": "https://github.com/example/tool",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    source = tmp_path / "evals"
+    source.mkdir()
+    (source / "example__tool.json").write_text(
+        json.dumps(
+            {
+                "name": "example__tool",
+                "display_name": "Example Tool",
+                "description": "Useful MCP server",
+                "category": "Development",
+                "quality_score": 77,
+                "programming_language": "Python",
+                "github_info": {
+                    "url": "https://github.com/example/tool",
+                    "stars": 42,
+                    "contributors": 3,
+                    "releases": True,
+                    "ci_cd": True,
+                    "latest_commit_hash": "abc123",
+                },
+                "server": {"type": "local"},
+                "protocol_features": {"implementing_tools": True},
+                "user_config": {
+                    "token": {"sensitive": True, "required": True},
+                    "url": {"sensitive": False, "required": True},
+                },
+                "last_scraped_at": "2026-07-22T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = build_signals(source, catalog)
+
+    assert result["source_files_seen"] == 1
+    assert result["matched_entry_count"] == 1
+    signal = result["signals"]["example/tool"]
+    assert signal["quality_score"] == 77
+    assert signal["github_info"]["stars"] == 42
+    assert signal["protocol_features"] == {"implementing_tools": True}
+    assert signal["sensitive_config_fields"] == ["token"]
+    assert signal["required_sensitive_config_fields"] == ["token"]
+
+
+def test_build_signals_matches_by_remote_url(tmp_path):
+    catalog = tmp_path / "repos.yaml"
+    catalog.write_text(
+        yaml.safe_dump([{"name": "Example Remote", "url": "https://mcp.example.com/mcp"}]),
+        encoding="utf-8",
+    )
+    source = tmp_path / "evals"
+    source.mkdir()
+    (source / "remote.json").write_text(
+        json.dumps(
+            {
+                "name": "example__remote",
+                "server": {"type": "remote", "url": "https://mcp.example.com/mcp/"},
+                "user_config": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = build_signals(source, catalog)
+
+    assert result["matched_entry_count"] == 1
+    assert result["signals"]["Example Remote"]["server_type"] == "remote"


### PR DESCRIPTION
## Summary

- Add `scripts/import_archestra_signals.py` to import matching Archestra MCP evaluation signals into a generated sidecar.
- Add `data/external/archestra-signals.json` with matched external signals for current catalog entries.
- Document external signals as review inputs, not curator acceptance criteria.
- Add unit tests for GitHub/remote URL matching and sensitive config extraction.

## Verification

- `python3 scripts/import_archestra_signals.py /tmp/archestra-ref/archestra/mcp-catalog/data/mcp-evaluations`
- `python3 scripts/import_archestra_signals.py /tmp/archestra-ref/archestra/mcp-catalog/data/mcp-evaluations --check`
- `python3 scripts/validate_repos_yaml.py`
- `/Users/tuximac/projects/awesome-agentic-devops/.venv/bin/python -m pytest -q`
- `python3 scripts/run_mock_eval_scenarios.py`
