### PR TITLE
feat: add data-platform MCP entries from rizzdev list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated, **official-first** catalog of MCP servers, agent skills, AI agents, f
 
 Most agent lists stop at discovery. This one is built for operators:
 
-- **Official-first, community-inclusive** — 67 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
+- **Official-first, community-inclusive** — 70 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
 - **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
 - **Audited by CI** — GitHub repository entries are checked weekly for reachability and archived status; non-GitHub documentation links are outside this automated check and require curator review.
 - **Installable, not just readable** — [one command](#install-skills-into-your-coding-agent) installs hundreds of skills from cataloged Google, Microsoft, Azure, Azure DevOps, and Harness sources — plus a separate community set — into Claude Code, Cursor, Codex, VS Code, or Antigravity.
@@ -58,7 +58,7 @@ At minimum, record an explicit approval before any write-capable agent mutates i
 | SRE incident response | [grafana/mcp-grafana](https://github.com/grafana/mcp-grafana)<br>[datadog-labs/mcp-server](https://github.com/datadog-labs/mcp-server)<br>[Elastic Agent Builder MCP server docs](https://www.elastic.co/docs/explore-analyze/ai-features/agent-builder/mcp-server)<br>[PagerDuty/pagerduty-mcp-server](https://github.com/PagerDuty/pagerduty-mcp-server) | Official observability and incident-management MCPs for metrics, logs, traces, indexed operational data, alerts, incidents, and on-call context. |
 | FinOps and cloud cost | [vantage-sh/vantage-mcp-server](https://github.com/vantage-sh/vantage-mcp-server) | Official Vantage MCP server for cloud spend analysis, budgets, anomalies, reports, and provider-resource cost context across Vantage-connected providers. |
 | Security and code quality | [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top-10/)<br>[SonarSource/sonarqube-mcp-server](https://github.com/SonarSource/sonarqube-mcp-server)<br>[okta/okta-mcp-server](https://github.com/okta/okta-mcp-server)<br>[Snyk Studio MCP docs](https://docs.snyk.io/evo-by-snyk/agentic-security-with-snyk-studio/getting-started-with-snyk-studio)<br>[snyk/studio-mcp](https://github.com/snyk/studio-mcp)<br>[Wiz WIN MCP Server docs](https://docs.wiz.io/dev/win-mcp-server)<br>[CrowdStrike/falcon-mcp](https://github.com/CrowdStrike/falcon-mcp)<br>[DopplerHQ/mcp-server](https://github.com/DopplerHQ/mcp-server) | Official MCPs and security resources for MCP threat modeling, code quality, application security, identity-aware workflows, secrets management, agent security, cloud-security posture, and Falcon-platform SOC automation. |
-| Data platform operations | [mongodb-js/mongodb-mcp-server](https://github.com/mongodb-js/mongodb-mcp-server)<br>[redis/mcp-redis](https://github.com/redis/mcp-redis) | Official database MCP servers for MongoDB and Redis operational context, cache/session data, vector search, streams, and data-platform agent workflows. |
+| Data platform operations | [mongodb-js/mongodb-mcp-server](https://github.com/mongodb-js/mongodb-mcp-server)<br>[redis/mcp-redis](https://github.com/redis/mcp-redis)<br>[googleapis/mcp-toolbox](https://github.com/googleapis/mcp-toolbox)<br>[dbt-labs/dbt-mcp](https://github.com/dbt-labs/dbt-mcp)<br>[bytebase/dbhub](https://github.com/bytebase/dbhub) | Official database and data-platform MCP servers for MongoDB, Redis, SQL databases, dbt, schema discovery, guarded query execution, semantic-layer context, and data-platform agent workflows. |
 | CI/CD and GitOps | [jenkinsci/mcp-server-plugin](https://github.com/jenkinsci/mcp-server-plugin)<br>[argoproj-labs/mcp-for-argocd](https://github.com/argoproj-labs/mcp-for-argocd)<br>[harness/mcp-server](https://github.com/harness/mcp-server) | Official Jenkins, Argo Project, and Harness resources for pipeline, build, deployment, rollback, and GitOps workflows. |
 | MCP development and governance | [modelcontextprotocol/python-sdk](https://github.com/modelcontextprotocol/python-sdk)<br>[modelcontextprotocol/typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk)<br>[modelcontextprotocol/registry](https://github.com/modelcontextprotocol/registry)<br>[Docker MCP Catalog and Toolkit](https://docs.docker.com/ai/mcp-catalog-and-toolkit/) | Official SDKs, registry, and Docker governance surfaces for building, packaging, and controlling DevOps MCP servers. |
 | Agent frameworks and templates | [google/adk-python](https://github.com/google/adk-python)<br>[GoogleCloudPlatform/agent-starter-pack](https://github.com/GoogleCloudPlatform/agent-starter-pack) | Official Google agent framework and production templates with CI/CD, evaluation, and observability. |
@@ -80,6 +80,9 @@ Pass `--dry-run` to preview first. Commands for Cursor, Codex, VS Code, Antigrav
 
 | Date | Entry | Category |
 | --- | --- | --- |
+| 2026-07-22 | [googleapis/mcp-toolbox](https://github.com/googleapis/mcp-toolbox) | Data platform / database toolbox |
+| 2026-07-22 | [dbt-labs/dbt-mcp](https://github.com/dbt-labs/dbt-mcp) | Data platform / dbt |
+| 2026-07-22 | [bytebase/dbhub](https://github.com/bytebase/dbhub) | Data platform / guarded SQL MCP |
 | 2026-07-22 | [Linear MCP server docs](https://linear.app/docs/mcp) | DevOps / Linear issue and roadmap workflows |
 | 2026-07-18 | [DopplerHQ/mcp-server](https://github.com/DopplerHQ/mcp-server) | Security / Doppler secrets management |
 | 2026-07-17 | [CrowdStrike/falcon-mcp](https://github.com/CrowdStrike/falcon-mcp) | Security / CrowdStrike Falcon SOC automation |
@@ -230,6 +233,9 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines 
 | --- | --- | --- |
 | [mongodb-js/mongodb-mcp-server](https://github.com/mongodb-js/mongodb-mcp-server) | 🟢 🔵 🛡️ ⚠️ | Official MongoDB MCP server (public preview) connecting agents to MongoDB Community, Enterprise, and Atlas deployments. |
 | [redis/mcp-redis](https://github.com/redis/mcp-redis) | 🟢 🔵 🛡️ ⚠️ | Official Redis MCP Server for natural-language Redis data management, cache/session workflows, vector search, streams, pub/sub, and Redis documentation lookup. |
+| [googleapis/mcp-toolbox](https://github.com/googleapis/mcp-toolbox) | 🟢 🔵 🛡️ 📊 ⚠️ | Official Google APIs MCP Toolbox for Databases with self-hosted database tools, SDKs, integrated auth, and OpenTelemetry support. |
+| [dbt-labs/dbt-mcp](https://github.com/dbt-labs/dbt-mcp) | 🟢 🔵 🛡️ ⚠️ | Official dbt Labs MCP server for dbt Core, dbt Fusion, and dbt Platform context, including Discovery API, Semantic Layer, project search, and dbt CLI tools. |
+| [bytebase/dbhub](https://github.com/bytebase/dbhub) | 🟢 🔵 🛡️ ⚠️ | Bytebase-maintained DBHub MCP server for Postgres, MySQL, MariaDB, SQL Server, and SQLite with token-efficient schema search, query execution, read-only mode, row limits, and timeouts. |
 
 ### Official FinOps and Cloud-Cost MCP Servers
 

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1537,3 +1537,75 @@
     - 🛡️
     - 📊
     - ⚠️
+
+- name: googleapis/mcp-toolbox
+  url: https://github.com/googleapis/mcp-toolbox
+  category: official-data-platform-mcp-servers
+  type: mcp-server
+  framework: MCP + database toolbox
+  primary_language: Go
+  cloud_provider: multi-cloud
+  use_cases:
+    - database-schema-exploration
+    - sql-querying-and-tooling
+    - enterprise-database-agent-access
+    - opentelemetry-instrumented-data-tools
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: "yes"
+  maturity: production-adjacent
+  risk_notes: "Generic database tools can execute SQL against production databases; configure read-only database users for exploration, rely on IAM/integrated auth where supported, and require approval before write SQL or schema-changing tools."
+  operator_note: "Official Google APIs MCP Toolbox for Databases, renamed from genai-toolbox, providing a self-hosted MCP server and SDKs for Postgres, MySQL, Spanner, BigQuery, Redis, MongoDB, Elasticsearch, and other databases; identified from rizzdev's Databases list."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - 📊
+    - ⚠️
+
+- name: dbt-labs/dbt-mcp
+  url: https://github.com/dbt-labs/dbt-mcp
+  category: official-data-platform-mcp-servers
+  type: mcp-server
+  framework: MCP + dbt
+  primary_language: Python
+  cloud_provider: multi-cloud
+  use_cases:
+    - dbt-project-context
+    - semantic-layer-querying
+    - data-lineage-and-model-inspection
+    - data-platform-agent-workflows
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: partial
+  maturity: production-adjacent
+  risk_notes: "dbt CLI tools can modify project artifacts, models, sources, and warehouse objects; use dev targets or read-only roles for exploration and require approval before execution that changes data models or warehouse state."
+  operator_note: "Official dbt Labs MCP server for dbt Core, dbt Fusion, and dbt Platform context, including Discovery API, Semantic Layer SQL execution, project search, and dbt CLI tools; identified from rizzdev's Data & Analytics list."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - ⚠️
+
+- name: bytebase/dbhub
+  url: https://github.com/bytebase/dbhub
+  category: official-data-platform-mcp-servers
+  type: mcp-server
+  framework: MCP + SQL databases
+  primary_language: TypeScript
+  cloud_provider: multi-cloud
+  use_cases:
+    - multi-database-schema-discovery
+    - guarded-sql-querying
+    - local-development-database-context
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: partial
+  maturity: production-adjacent
+  risk_notes: "DBHub supports guardrails such as read-only mode, row limiting, and query timeout, but database credentials still define actual blast radius. Use read-only users by default and require approval before write SQL or production database access."
+  operator_note: "Bytebase-maintained DBHub MCP server for Postgres, MySQL, MariaDB, SQL Server, and SQLite with token-efficient schema search, query execution, read-only mode, row limits, and timeouts; identified from rizzdev's Databases list."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - ⚠️


### PR DESCRIPTION
## Summary

- Add three self-hostable data-platform MCP entries surfaced by rizzdev's Databases/Data & Analytics sections:
  - `googleapis/mcp-toolbox`
  - `dbt-labs/dbt-mcp`
  - `bytebase/dbhub`
- Update the README top-pick row for data platform operations.
- Score all three with explicit database/warehouse blast-radius notes and approval guidance.
- Update README catalog table, recently-added list, and catalog count.

## Verification

- `python3 scripts/validate_repos_yaml.py`
- `python3 scripts/sync_readme_counts.py --check`
- `/Users/tuximac/projects/awesome-agentic-devops/.venv/bin/python -m pytest -q`
- `python3 scripts/run_mock_eval_scenarios.py`

Reference input: https://github.com/rizzdev/awesome-mcp-open
