### PR TITLE
feat: add browser automation MCP entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated, **official-first** catalog of MCP servers, agent skills, AI agents, f
 
 Most agent lists stop at discovery. This one is built for operators:
 
-- **Official-first, community-inclusive** — 68 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
+- **Official-first, community-inclusive** — 68 entries organized into 15 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
 - **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
 - **Audited by CI** — GitHub repository entries are checked weekly for reachability and archived status; non-GitHub documentation links are outside this automated check and require curator review.
 - **Installable, not just readable** — [one command](#install-skills-into-your-coding-agent) installs hundreds of skills from cataloged Google, Microsoft, Azure, Azure DevOps, and Harness sources — plus a separate community set — into Claude Code, Cursor, Codex, VS Code, or Antigravity.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated, **official-first** catalog of MCP servers, agent skills, AI agents, f
 
 Most agent lists stop at discovery. This one is built for operators:
 
-- **Official-first, community-inclusive** — 67 entries organized into 14 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
+- **Official-first, community-inclusive** — 69 entries organized into 15 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
 - **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
 - **Audited by CI** — GitHub repository entries are checked weekly for reachability and archived status; non-GitHub documentation links are outside this automated check and require curator review.
 - **Installable, not just readable** — [one command](#install-skills-into-your-coding-agent) installs hundreds of skills from cataloged Google, Microsoft, Azure, Azure DevOps, and Harness sources — plus a separate community set — into Claude Code, Cursor, Codex, VS Code, or Antigravity.
@@ -61,6 +61,7 @@ At minimum, record an explicit approval before any write-capable agent mutates i
 | Data platform operations | [mongodb-js/mongodb-mcp-server](https://github.com/mongodb-js/mongodb-mcp-server)<br>[redis/mcp-redis](https://github.com/redis/mcp-redis) | Official database MCP servers for MongoDB and Redis operational context, cache/session data, vector search, streams, and data-platform agent workflows. |
 | CI/CD and GitOps | [jenkinsci/mcp-server-plugin](https://github.com/jenkinsci/mcp-server-plugin)<br>[argoproj-labs/mcp-for-argocd](https://github.com/argoproj-labs/mcp-for-argocd)<br>[harness/mcp-server](https://github.com/harness/mcp-server) | Official Jenkins, Argo Project, and Harness resources for pipeline, build, deployment, rollback, and GitOps workflows. |
 | MCP development and governance | [modelcontextprotocol/python-sdk](https://github.com/modelcontextprotocol/python-sdk)<br>[modelcontextprotocol/typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk)<br>[modelcontextprotocol/registry](https://github.com/modelcontextprotocol/registry)<br>[Docker MCP Catalog and Toolkit](https://docs.docker.com/ai/mcp-catalog-and-toolkit/) | Official SDKs, registry, and Docker governance surfaces for building, packaging, and controlling DevOps MCP servers. |
+| Browser automation and debugging | [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp)<br>[microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp) | Official browser automation MCP servers for web-app QA, performance tracing, network/console inspection, and accessibility-tree-driven browser workflows. |
 | Agent frameworks and templates | [google/adk-python](https://github.com/google/adk-python)<br>[GoogleCloudPlatform/agent-starter-pack](https://github.com/GoogleCloudPlatform/agent-starter-pack) | Official Google agent framework and production templates with CI/CD, evaluation, and observability. |
 
 ## Install skills into your coding agent
@@ -80,6 +81,8 @@ Pass `--dry-run` to preview first. Commands for Cursor, Codex, VS Code, Antigrav
 
 | Date | Entry | Category |
 | --- | --- | --- |
+| 2026-07-23 | [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) | Browser automation / Chrome DevTools |
+| 2026-07-23 | [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp) | Browser automation / Playwright |
 | 2026-07-22 | [Linear MCP server docs](https://linear.app/docs/mcp) | DevOps / Linear issue and roadmap workflows |
 | 2026-07-18 | [DopplerHQ/mcp-server](https://github.com/DopplerHQ/mcp-server) | Security / Doppler secrets management |
 | 2026-07-17 | [CrowdStrike/falcon-mcp](https://github.com/CrowdStrike/falcon-mcp) | Security / CrowdStrike Falcon SOC automation |
@@ -223,6 +226,13 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines 
 | Repo | Labels | Operator note |
 | --- | --- | --- |
 | [jgraph/drawio-mcp](https://github.com/jgraph/drawio-mcp) | 🟢 🔵 🛡️ | draw.io MCP server and Claude Code plugin for generating, opening, and exporting draw.io diagrams with shape search. |
+
+### Official Browser Automation and Debugging MCP Servers
+
+| Repo | Labels | Operator note |
+| --- | --- | --- |
+| [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) | 🟢 🔵 🛡️ 📊 ⚠️ | Official Chrome DevTools MCP server for browser debugging, performance tracing, network inspection, and DOM automation in coding agents. |
+| [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp) | 🟢 🔵 🛡️ ⚠️ | Official Microsoft Playwright MCP server exposing accessibility-tree browser automation for web QA, scraping, debugging, and exploratory agent loops. |
 
 ### Official Data Platform MCP Servers
 

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1537,3 +1537,52 @@
     - 🛡️
     - 📊
     - ⚠️
+
+- name: ChromeDevTools/chrome-devtools-mcp
+  url: https://github.com/ChromeDevTools/chrome-devtools-mcp
+  category: official-browser-automation-mcp-servers
+  type: mcp-server
+  framework: MCP + Chrome DevTools Protocol
+  primary_language: TypeScript
+  cloud_provider: none
+  use_cases:
+    - browser-debugging
+    - performance-tracing
+    - network-and-console-inspection
+    - web-app-qa-automation
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: "yes"
+  maturity: production-adjacent
+  risk_notes: "Controls a live Chrome/Chrome for Testing instance and exposes browser state, console/network data, screenshots, downloads, and optional extension loading. Disable usage statistics with --no-usage-statistics or CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS, use allow/block URL patterns, and avoid authenticated production sessions unless explicitly approved."
+  operator_note: "Official Chrome DevTools MCP server for coding agents, enabling reliable browser debugging, performance tracing, network inspection, and DOM automation; identified from rizzdev's Browser Automation list."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - 📊
+    - ⚠️
+
+- name: microsoft/playwright-mcp
+  url: https://github.com/microsoft/playwright-mcp
+  category: official-browser-automation-mcp-servers
+  type: mcp-server
+  framework: MCP + Playwright
+  primary_language: TypeScript
+  cloud_provider: none
+  use_cases:
+    - browser-automation
+    - accessibility-tree-web-testing
+    - exploratory-qa
+    - self-healing-test-debugging
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: partial
+  maturity: production-adjacent
+  risk_notes: "Can drive real browsers, click through authenticated sessions, submit forms, download files, and modify web app state. Prefer isolated browser profiles/test environments, least-privilege test accounts, and explicit approval before actions that submit data or affect production systems."
+  operator_note: "Official Microsoft Playwright MCP server exposing browser automation through Playwright's accessibility tree for web QA, scraping, debugging, and exploratory agent loops; identified from rizzdev's Browser Automation list."
+  labels:
+    - 🟢
+    - 🔵
+    - 🛡️
+    - ⚠️

--- a/tests/test_readme_counts.py
+++ b/tests/test_readme_counts.py
@@ -28,5 +28,10 @@ def test_readme_intro_counts_match_catalog():
 
 def test_counts_phrase_describes_readme_sections_not_yaml_categories():
     phrase = expected_counts_phrase()
-    assert phrase.endswith("entries organized into 14 catalog sections")
+    readme_sections = [
+        line for line in README.read_text().splitlines() if line.startswith("### ")
+    ]
+    assert phrase.endswith(
+        f"entries organized into {len(readme_sections)} catalog sections"
+    )
     assert COUNTS_PATTERN.fullmatch(phrase)


### PR DESCRIPTION
## Summary

- Add official browser automation/debugging MCP entries from rizzdev's Browser Automation list:
  - `ChromeDevTools/chrome-devtools-mcp`
  - `microsoft/playwright-mcp`
- Add a dedicated README catalog section for browser automation and debugging MCP servers.
- Capture safety notes for authenticated browser sessions, downloads/screenshots, usage statistics, URL allow/block patterns, and test-account isolation.
- Make the README section-count test derive the expected section count dynamically so new catalog sections do not require hard-coded test edits.

## Verification

- `python3 scripts/validate_repos_yaml.py`
- `python3 scripts/sync_readme_counts.py --check`
- `/Users/tuximac/projects/awesome-agentic-devops/.venv/bin/python -m pytest -q`
- `python3 scripts/run_mock_eval_scenarios.py`

Reference input: https://github.com/rizzdev/awesome-mcp-open
