### PR TITLE
Fix SonarQube high-severity findings

### DIFF
--- a/.github/workflows/terraform-cloud-gcs-sample.yml
+++ b/.github/workflows/terraform-cloud-gcs-sample.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.7
 

--- a/scripts/audit_github_repos.py
+++ b/scripts/audit_github_repos.py
@@ -37,6 +37,22 @@ class AuditResult:
     warnings: list[str] = field(default_factory=list)
 
 
+def resolve_cli_path(path: Path, root: Path | None = None) -> Path:
+    """Resolve a CLI path and require it to remain inside the working tree."""
+    allowed_root = (root or Path.cwd()).resolve()
+    candidate = path.expanduser()
+    resolved = (
+        candidate.resolve()
+        if candidate.is_absolute()
+        else (allowed_root / candidate).resolve()
+    )
+    try:
+        resolved.relative_to(allowed_root)
+    except ValueError as exc:
+        raise ValueError(f"path escapes the working tree: {path}") from exc
+    return resolved
+
+
 def parse_github_repo(value: str) -> tuple[str, str]:
     if value.startswith("http://") or value.startswith("https://"):
         parsed = urlparse(value)
@@ -215,9 +231,16 @@ def main() -> int:
     parser.add_argument("--fail-on-unreachable", action="store_true")
     args = parser.parse_args()
 
-    entries = load_entries(args.data)
+    try:
+        data_path = resolve_cli_path(args.data)
+        json_path = resolve_cli_path(args.json_output)
+        markdown_path = resolve_cli_path(args.markdown_output)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    entries = load_entries(data_path)
     results = audit_entries(entries, workers=max(1, args.workers))
-    write_report(results, json_path=args.json_output, markdown_path=args.markdown_output)
+    write_report(results, json_path=json_path, markdown_path=markdown_path)
 
     summary = build_summary(results)
     print(
@@ -227,8 +250,8 @@ def main() -> int:
         f"{summary['archived']} archived, "
         f"{summary['with_warnings']} with warnings"
     )
-    print(f"JSON report: {args.json_output}")
-    print(f"Markdown report: {args.markdown_output}")
+    print(f"JSON report: {json_path}")
+    print(f"Markdown report: {markdown_path}")
 
     if args.fail_on_unreachable and summary["unreachable"]:
         return 1

--- a/scripts/install_skills.py
+++ b/scripts/install_skills.py
@@ -186,9 +186,10 @@ def _path_within(root: Path, untrusted_path: str | Path) -> Path:
 
 def _safe_extract(tar: tarfile.TarFile, dest: Path) -> None:
     """Extract regular files/directories without honoring archive links."""
-    dest.mkdir(parents=True, exist_ok=True)
+    safe_dest = _path_within(dest.parent, dest.name)
+    safe_dest.mkdir(parents=True, exist_ok=True)
     for member in tar.getmembers():
-        target = _path_within(dest, member.name)
+        target = _path_within(safe_dest, member.name)
         if member.isdir():
             target.mkdir(parents=True, exist_ok=True)
             continue

--- a/scripts/install_skills.py
+++ b/scripts/install_skills.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import re
 import shutil
 import ssl
 import sys
@@ -73,6 +74,7 @@ AGENT_SKILLS: dict[str, Path] = {
 
 # Folder names that hold a SKILL.md but are scaffolding, not a real skill.
 SKILL_NAME_IGNORE = {"template", "templates", "example", "examples"}
+OWNER_REPO_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\Z")
 
 # CA bundles shipped by the OS, used when the interpreter's own trust store is
 # empty. See _ssl_context().
@@ -138,6 +140,13 @@ def load_catalog_sources(
     return sources
 
 
+def _secure_ssl_context(cafile: str | None = None) -> ssl.SSLContext:
+    """Create a verified TLS context with an explicit modern protocol floor."""
+    context = ssl.create_default_context(cafile=cafile)
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
+    return context
+
+
 def _ssl_context() -> ssl.SSLContext:
     """A TLS context with a CA store that actually has certificates in it.
 
@@ -151,30 +160,52 @@ def _ssl_context() -> ssl.SSLContext:
     try:
         import certifi
 
-        return ssl.create_default_context(cafile=certifi.where())
+        return _secure_ssl_context(cafile=certifi.where())
     except ModuleNotFoundError:
         pass
 
-    context = ssl.create_default_context()
+    context = _secure_ssl_context()
     if context.get_ca_certs():
         return context
     for bundle in SYSTEM_CA_BUNDLES:
         if Path(bundle).exists():
-            return ssl.create_default_context(cafile=bundle)
+            return _secure_ssl_context(cafile=bundle)
     return context
 
 
+def _path_within(root: Path, untrusted_path: str | Path) -> Path:
+    """Resolve an untrusted path and require containment within ``root``."""
+    root_resolved = root.resolve()
+    target = (root_resolved / untrusted_path).resolve()
+    try:
+        target.relative_to(root_resolved)
+    except ValueError as exc:
+        raise SystemExit(f"unsafe path: {untrusted_path}") from exc
+    return target
+
+
 def _safe_extract(tar: tarfile.TarFile, dest: Path) -> None:
-    dest_resolved = dest.resolve()
+    """Extract regular files/directories without honoring archive links."""
+    dest.mkdir(parents=True, exist_ok=True)
     for member in tar.getmembers():
-        target = (dest / member.name).resolve()
-        if dest_resolved != target and dest_resolved not in target.parents:
-            raise SystemExit(f"unsafe path in archive: {member.name}")
-    tar.extractall(dest)
+        target = _path_within(dest, member.name)
+        if member.isdir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        if not member.isfile():
+            raise SystemExit(f"unsupported archive entry: {member.name}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        source = tar.extractfile(member)
+        if source is None:
+            raise SystemExit(f"could not read archive entry: {member.name}")
+        with source, target.open("wb") as output:
+            shutil.copyfileobj(source, output)
 
 
 def download_source(owner_repo: str, dest: Path) -> Path:
     """Download and extract a GitHub repo tarball; return the extracted root."""
+    if not OWNER_REPO_PATTERN.fullmatch(owner_repo):
+        raise SystemExit(f"invalid GitHub repository reference: {owner_repo!r}")
     last_error: Exception | None = None
     for branch in ("main", "master"):
         url = f"https://codeload.github.com/{owner_repo}/tar.gz/refs/heads/{branch}"
@@ -391,21 +422,24 @@ def install_for_agent(agent: str, skills: list[tuple[str, Path]], args: argparse
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
+    repos_path = _path_within(Path.cwd(), args.repos)
+
     if args.list_sources:
         print("Skill sources (use with --source):")
-        _print_sources(args.repos)
+        _print_sources(str(repos_path))
         return 0
 
     if not args.source and not selected_categories(args):
         print("Choose what to install with --official, --community, --all, or --source.")
         print("\nAvailable skill sources:")
-        _print_sources(args.repos)
+        _print_sources(str(repos_path))
         print("\nExamples:")
         print("  --agent claude-code --official")
         print("  --agent claude-code --source google/skills --filter cloud")
         return 2
 
     agents = sorted(AGENT_SKILLS) if args.agent == "all" else [args.agent]
+    args.repos = str(repos_path)
     owner_repos = resolve_sources(args)
 
     with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/run_mock_eval_scenarios.py
+++ b/scripts/run_mock_eval_scenarios.py
@@ -9,6 +9,22 @@ from typing import Any
 import yaml
 
 
+def resolve_cli_path(path: Path, root: Path | None = None) -> Path:
+    """Resolve a CLI path and require it to remain inside the working tree."""
+    allowed_root = (root or Path.cwd()).resolve()
+    candidate = path.expanduser()
+    resolved = (
+        candidate.resolve()
+        if candidate.is_absolute()
+        else (allowed_root / candidate).resolve()
+    )
+    try:
+        resolved.relative_to(allowed_root)
+    except ValueError as exc:
+        raise ValueError(f"path escapes the working tree: {path}") from exc
+    return resolved
+
+
 def load_scenarios(path: Path) -> list[dict[str, Any]]:
     with path.open("r", encoding="utf-8") as handle:
         scenarios = yaml.safe_load(handle)
@@ -155,16 +171,23 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    scenarios = load_scenarios(args.scenarios)
+    try:
+        scenarios_path = resolve_cli_path(args.scenarios)
+        json_path = resolve_cli_path(args.json_output)
+        markdown_path = resolve_cli_path(args.markdown_output)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    scenarios = load_scenarios(scenarios_path)
     results = [evaluate_scenario(scenario) for scenario in scenarios]
-    write_reports(results, json_path=args.json_output, markdown_path=args.markdown_output)
+    write_reports(results, json_path=json_path, markdown_path=markdown_path)
     summary = summarize_results(results)
     print(
         "Mock eval complete: "
         f"{summary['passed']}/{summary['total']} passed, {summary['failed']} failed"
     )
-    print(f"JSON report: {args.json_output}")
-    print(f"Markdown report: {args.markdown_output}")
+    print(f"JSON report: {json_path}")
+    print(f"Markdown report: {markdown_path}")
     return 0 if summary["failed"] == 0 else 1
 
 

--- a/scripts/validate_repos_yaml.py
+++ b/scripts/validate_repos_yaml.py
@@ -47,6 +47,54 @@ def _entry_name(entry: dict[str, Any], index: int) -> str:
     return str(entry.get("name", f"entry #{index + 1}"))
 
 
+def resolve_cli_path(path: Path, root: Path | None = None) -> Path:
+    """Resolve a CLI path and require it to remain inside the working tree."""
+    allowed_root = (root or Path.cwd()).resolve()
+    candidate = path.expanduser()
+    resolved = (
+        candidate.resolve()
+        if candidate.is_absolute()
+        else (allowed_root / candidate).resolve()
+    )
+    try:
+        resolved.relative_to(allowed_root)
+    except ValueError as exc:
+        raise ValidationError(f"path escapes the working tree: {path}") from exc
+    return resolved
+
+
+def _require_fields(entry: dict[str, Any], name: str) -> None:
+    for field in REQUIRED_FIELDS:
+        if field not in entry:
+            raise ValidationError(f"{name}: missing required field: {field}")
+
+
+def _validate_choice(name: str, field: str, value: Any, allowed: set[Any]) -> None:
+    if value not in allowed:
+        expected = ", ".join(str(item) for item in sorted(allowed, key=str))
+        raise ValidationError(
+            f"{name}: invalid {field} {value!r}; expected one of: {expected}"
+        )
+
+
+def _validate_entry(entry: dict[str, Any], index: int) -> None:
+    name = _entry_name(entry, index)
+    _require_fields(entry, name)
+    _validate_choice(name, "action_level", entry["action_level"], ALLOWED_ACTION_LEVELS)
+    _validate_choice(name, "maturity", entry["maturity"], ALLOWED_MATURITY)
+    _validate_choice(
+        name,
+        "evidence_tracing",
+        entry["evidence_tracing"],
+        ALLOWED_EVIDENCE_TRACING,
+    )
+    if entry["human_approval"] not in ALLOWED_HUMAN_APPROVAL:
+        raise ValidationError(f"{name}: human_approval must be true, false, or unknown")
+    for field in ("labels", "use_cases"):
+        if not isinstance(entry[field], list):
+            raise ValidationError(f"{name}: {field} must be a list")
+
+
 def validate_entries(entries: Any) -> list[dict[str, Any]]:
     if not isinstance(entries, list):
         raise ValidationError("data/repos.yaml must contain a list of repo entries")
@@ -54,43 +102,7 @@ def validate_entries(entries: Any) -> list[dict[str, Any]]:
     for index, entry in enumerate(entries):
         if not isinstance(entry, dict):
             raise ValidationError(f"entry #{index + 1} must be a mapping")
-
-        name = _entry_name(entry, index)
-        for field in REQUIRED_FIELDS:
-            if field not in entry:
-                raise ValidationError(f"{name}: missing required field: {field}")
-
-        if entry["action_level"] not in ALLOWED_ACTION_LEVELS:
-            allowed = ", ".join(sorted(ALLOWED_ACTION_LEVELS))
-            raise ValidationError(
-                f"{name}: invalid action_level {entry['action_level']!r}; "
-                f"expected one of: {allowed}"
-            )
-
-        if entry["maturity"] not in ALLOWED_MATURITY:
-            allowed = ", ".join(sorted(ALLOWED_MATURITY))
-            raise ValidationError(
-                f"{name}: invalid maturity {entry['maturity']!r}; "
-                f"expected one of: {allowed}"
-            )
-
-        if entry["evidence_tracing"] not in ALLOWED_EVIDENCE_TRACING:
-            allowed = ", ".join(sorted(ALLOWED_EVIDENCE_TRACING))
-            raise ValidationError(
-                f"{name}: invalid evidence_tracing {entry['evidence_tracing']!r}; "
-                f"expected one of: {allowed}"
-            )
-
-        if entry["human_approval"] not in ALLOWED_HUMAN_APPROVAL:
-            raise ValidationError(
-                f"{name}: human_approval must be true, false, or unknown"
-            )
-
-        if not isinstance(entry["labels"], list):
-            raise ValidationError(f"{name}: labels must be a list")
-
-        if not isinstance(entry["use_cases"], list):
-            raise ValidationError(f"{name}: use_cases must be a list")
+        _validate_entry(entry, index)
 
     return entries
 
@@ -102,8 +114,9 @@ def validate_file(path: Path) -> list[dict[str, Any]]:
 
 
 def main() -> int:
-    path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("data/repos.yaml")
+    supplied_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("data/repos.yaml")
     try:
+        path = resolve_cli_path(supplied_path)
         entries = validate_file(path)
     except (OSError, yaml.YAMLError, ValidationError) as exc:
         print(f"Validation failed: {exc}", file=sys.stderr)

--- a/tests/test_audit_github_repos.py
+++ b/tests/test_audit_github_repos.py
@@ -8,6 +8,7 @@ from scripts.audit_github_repos import (
     audit_repo,
     build_summary,
     parse_github_repo,
+    resolve_cli_path,
     write_report,
 )
 
@@ -139,3 +140,15 @@ def test_write_report_outputs_json_and_markdown(tmp_path):
     assert report["summary"]["total"] == 1
     assert report["results"][0]["name"] == "antonbabenko/terraform-skill"
     assert "| antonbabenko/terraform-skill | yes |" in markdown
+
+
+def test_resolve_cli_path_rejects_working_tree_escape(tmp_path):
+    with pytest.raises(ValueError, match="escapes the working tree"):
+        resolve_cli_path(Path("../outside.json"), root=tmp_path / "repo")
+
+
+def test_resolve_cli_path_accepts_nested_path(tmp_path):
+    root = tmp_path / "repo"
+    assert resolve_cli_path(Path("reports/audit.json"), root=root) == (
+        root / "reports/audit.json"
+    ).resolve()

--- a/tests/test_audit_github_repos.py
+++ b/tests/test_audit_github_repos.py
@@ -143,8 +143,10 @@ def test_write_report_outputs_json_and_markdown(tmp_path):
 
 
 def test_resolve_cli_path_rejects_working_tree_escape(tmp_path):
+    untrusted_path = Path("../outside.json")
+    root = tmp_path / "repo"
     with pytest.raises(ValueError, match="escapes the working tree"):
-        resolve_cli_path(Path("../outside.json"), root=tmp_path / "repo")
+        resolve_cli_path(untrusted_path, root=root)
 
 
 def test_resolve_cli_path_accepts_nested_path(tmp_path):

--- a/tests/test_install_skills.py
+++ b/tests/test_install_skills.py
@@ -6,8 +6,10 @@ deterministically without network access.
 """
 
 import argparse
+import io
 import json
 import sys
+import tarfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -233,6 +235,7 @@ def test_ssl_context_falls_back_to_the_os_ca_bundle(tmp_path, monkeypatch):
 
     assert context.cafile == str(bundle), "should load the first bundle that exists"
     assert calls == [None, str(bundle)], "should try the default store first"
+    assert context.minimum_version == install_skills.ssl.TLSVersion.TLSv1_2
 
 
 def test_ssl_context_keeps_a_healthy_store(tmp_path, monkeypatch):
@@ -252,6 +255,42 @@ def test_ssl_context_survives_having_no_bundle_anywhere(tmp_path, monkeypatch):
     patch_ssl(monkeypatch, (str(tmp_path / "absent.pem"),))
 
     assert install_skills._ssl_context() is not None
+
+
+def test_safe_extract_rejects_parent_traversal(tmp_path):
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w:gz") as archive:
+        info = tarfile.TarInfo("../escape.txt")
+        contents = b"escape"
+        info.size = len(contents)
+        archive.addfile(info, io.BytesIO(contents))
+    payload.seek(0)
+
+    with tarfile.open(fileobj=payload, mode="r:gz") as archive:
+        try:
+            install_skills._safe_extract(archive, tmp_path / "dest")
+        except SystemExit as exc:
+            assert "unsafe path" in str(exc)
+        else:
+            raise AssertionError("parent traversal must be rejected")
+
+
+def test_safe_extract_rejects_symbolic_links(tmp_path):
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w:gz") as archive:
+        info = tarfile.TarInfo("repo/link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "../../outside"
+        archive.addfile(info)
+    payload.seek(0)
+
+    with tarfile.open(fileobj=payload, mode="r:gz") as archive:
+        try:
+            install_skills._safe_extract(archive, tmp_path / "dest")
+        except SystemExit as exc:
+            assert "unsupported archive entry" in str(exc)
+        else:
+            raise AssertionError("archive links must be rejected")
 
 
 def flag_args(**flags):

--- a/tests/test_mock_eval_scenarios.py
+++ b/tests/test_mock_eval_scenarios.py
@@ -149,5 +149,7 @@ def test_write_reports_outputs_json_and_markdown(tmp_path):
 
 
 def test_resolve_cli_path_rejects_working_tree_escape(tmp_path):
+    untrusted_path = Path("../../outside.yaml")
+    root = tmp_path / "repo"
     with pytest.raises(ValueError, match="escapes the working tree"):
-        resolve_cli_path(Path("../../outside.yaml"), root=tmp_path / "repo")
+        resolve_cli_path(untrusted_path, root=root)

--- a/tests/test_mock_eval_scenarios.py
+++ b/tests/test_mock_eval_scenarios.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 
+import pytest
+
 from scripts.run_mock_eval_scenarios import (
     evaluate_scenario,
     load_scenarios,
+    resolve_cli_path,
     summarize_results,
     write_reports,
 )
@@ -143,3 +146,8 @@ def test_write_reports_outputs_json_and_markdown(tmp_path):
     assert "| terraform_destroy | yes | approval-required |" in markdown_path.read_text(
         encoding="utf-8"
     )
+
+
+def test_resolve_cli_path_rejects_working_tree_escape(tmp_path):
+    with pytest.raises(ValueError, match="escapes the working tree"):
+        resolve_cli_path(Path("../../outside.yaml"), root=tmp_path / "repo")

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -8,6 +8,7 @@ from scripts.validate_repos_yaml import (
     ALLOWED_MATURITY,
     REQUIRED_FIELDS,
     ValidationError,
+    resolve_cli_path,
     validate_entries,
     validate_file,
 )
@@ -84,3 +85,8 @@ def test_rejects_non_list_yaml(tmp_path):
 
     with pytest.raises(ValidationError, match="must contain a list"):
         validate_file(yaml_path)
+
+
+def test_resolve_cli_path_rejects_working_tree_escape(tmp_path):
+    with pytest.raises(ValidationError, match="escapes the working tree"):
+        resolve_cli_path(Path("../outside.yaml"), root=tmp_path / "repo")

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -88,5 +88,7 @@ def test_rejects_non_list_yaml(tmp_path):
 
 
 def test_resolve_cli_path_rejects_working_tree_escape(tmp_path):
+    untrusted_path = Path("../outside.yaml")
+    root = tmp_path / "repo"
     with pytest.raises(ValidationError, match="escapes the working tree"):
-        resolve_cli_path(Path("../outside.yaml"), root=tmp_path / "repo")
+        resolve_cli_path(untrusted_path, root=root)


### PR DESCRIPTION
## Summary

- pin GitHub Actions dependencies to immutable commit SHAs
- constrain CLI-controlled file paths to the repository working tree
- enforce TLS 1.2 and safely extract downloaded skill archives without following links
- reduce repository validation cognitive complexity
- add regression coverage for traversal, malicious archives, symlinks, and TLS configuration

## Why

SonarQube reported 14 high-impact findings across the workflow and Python utilities. The root causes were mutable action tags, insufficient path containment at CLI file-system boundaries, archive extraction risks, implicit TLS protocol defaults, and an overly complex validation function.

## Impact

The command-line tools now reject paths that escape the working tree, downloaded skill archives cannot create links or write outside their extraction directory, TLS has an explicit modern minimum, and workflow dependencies are reproducible.

## Validation

- `python3 -m pytest -q` — 66 passed
- `python3 -m compileall -q scripts tests`
- `git diff --check`
- verified `scripts/validate_repos_yaml.py data/repos.yaml`
- verified a traversal-style CLI path is rejected before file access

SonarQube will resolve the cloud findings after this branch is analyzed.
