### PR TITLE
fix: resolve Sonar medium findings

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Audit catalog links
         env:
           GH_TOKEN: ${{ github.token }}
-        run: uv run --no-sync python scripts/audit_github_repos.py --workers 12 --fail-on-unreachable
+        run: uv run --no-sync --no-build python scripts/audit_github_repos.py --workers 12 --fail-on-unreachable
 
       # Publish results even when the audit fails — that is when they matter most.
       - name: Post report to the run summary

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -23,13 +23,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
+          python -m pip install uv==0.11.23
+          uv sync --locked --all-extras
 
       - name: Audit catalog links
         env:
           GH_TOKEN: ${{ github.token }}
-        run: python scripts/audit_github_repos.py --workers 12 --fail-on-unreachable
+        run: uv run python scripts/audit_github_repos.py --workers 12 --fail-on-unreachable
 
       # Publish results even when the audit fails — that is when they matter most.
       - name: Post report to the run summary

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,12 +24,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install uv==0.11.23
-          uv sync --locked --all-extras
+          uv sync --locked --all-extras --no-build --no-install-project
 
       - name: Audit catalog links
         env:
           GH_TOKEN: ${{ github.token }}
-        run: uv run python scripts/audit_github_repos.py --workers 12 --fail-on-unreachable
+        run: uv run --no-sync python scripts/audit_github_repos.py --workers 12 --fail-on-unreachable
 
       # Publish results even when the audit fails — that is when they matter most.
       - name: Post report to the run summary

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,19 +22,19 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install uv==0.11.23
-          uv sync --locked --all-extras
+          uv sync --locked --all-extras --no-build --no-install-project
 
       - name: Validate repo data
-        run: uv run python scripts/validate_repos_yaml.py
+        run: uv run --no-sync python scripts/validate_repos_yaml.py
 
       - name: Check generated skill catalog
-        run: uv run python scripts/sync_catalog_json.py --check
+        run: uv run --no-sync python scripts/sync_catalog_json.py --check
 
       - name: Check README catalog counts
-        run: uv run python scripts/sync_readme_counts.py --check
+        run: uv run --no-sync python scripts/sync_readme_counts.py --check
 
       - name: Run tests
-        run: uv run pytest -q
+        run: uv run --no-sync pytest -q
 
       - name: Run mock eval scenarios
-        run: uv run python scripts/run_mock_eval_scenarios.py
+        run: uv run --no-sync python scripts/run_mock_eval_scenarios.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,20 +21,20 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
+          python -m pip install uv==0.11.23
+          uv sync --locked --all-extras
 
       - name: Validate repo data
-        run: python scripts/validate_repos_yaml.py
+        run: uv run python scripts/validate_repos_yaml.py
 
       - name: Check generated skill catalog
-        run: python scripts/sync_catalog_json.py --check
+        run: uv run python scripts/sync_catalog_json.py --check
 
       - name: Check README catalog counts
-        run: python scripts/sync_readme_counts.py --check
+        run: uv run python scripts/sync_readme_counts.py --check
 
       - name: Run tests
-        run: pytest -q
+        run: uv run pytest -q
 
       - name: Run mock eval scenarios
-        run: python scripts/run_mock_eval_scenarios.py
+        run: uv run python scripts/run_mock_eval_scenarios.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,16 +25,16 @@ jobs:
           uv sync --locked --all-extras --no-build --no-install-project
 
       - name: Validate repo data
-        run: uv run --no-sync python scripts/validate_repos_yaml.py
+        run: uv run --no-sync --no-build python scripts/validate_repos_yaml.py
 
       - name: Check generated skill catalog
-        run: uv run --no-sync python scripts/sync_catalog_json.py --check
+        run: uv run --no-sync --no-build python scripts/sync_catalog_json.py --check
 
       - name: Check README catalog counts
-        run: uv run --no-sync python scripts/sync_readme_counts.py --check
+        run: uv run --no-sync --no-build python scripts/sync_readme_counts.py --check
 
       - name: Run tests
-        run: uv run --no-sync pytest -q
+        run: uv run --no-sync --no-build pytest -q
 
       - name: Run mock eval scenarios
-        run: uv run --no-sync python scripts/run_mock_eval_scenarios.py
+        run: uv run --no-sync --no-build python scripts/run_mock_eval_scenarios.py

--- a/agents/adk/terraform-plan-reviewer/terraform/gcs-sample/main.tf
+++ b/agents/adk/terraform-plan-reviewer/terraform/gcs-sample/main.tf
@@ -35,6 +35,17 @@ variable "bucket_name" {
   type = string
 }
 
+variable "log_bucket_name" {
+  description = "Name of an existing GCS bucket that receives access logs."
+  type        = string
+}
+
+resource "google_storage_bucket_iam_member" "log_writer" {
+  bucket = var.log_bucket_name
+  role   = "roles/storage.objectCreator"
+  member = "group:cloud-storage-analytics@google.com"
+}
+
 resource "google_storage_bucket" "sample" {
   name                        = var.bucket_name
   location                    = "US"
@@ -42,11 +53,18 @@ resource "google_storage_bucket" "sample" {
   public_access_prevention    = "enforced"
   force_destroy               = false
 
+  logging {
+    log_bucket        = var.log_bucket_name
+    log_object_prefix = "access-logs"
+  }
+
   labels = {
     env   = "dev"
     owner = "platform"
     app   = "terraform-plan-reviewer-test"
   }
+
+  depends_on = [google_storage_bucket_iam_member.log_writer]
 }
 
 output "bucket_name" {

--- a/install/all/install.sh
+++ b/install/all/install.sh
@@ -7,15 +7,16 @@
 # or --all to install a whole set.
 set -eu
 RAW="https://raw.githubusercontent.com/DevOpsAIguru123/awesome-agentic-devops/main"
+HTTPS_ONLY='=https'
 if ! command -v python3 >/dev/null 2>&1; then
   echo "Python 3 is required. Install it, then re-run." >&2
   exit 1
 fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
 # catalog.json lets install_skills.py read the catalog without PyYAML,
 # which a stock python3 (e.g. macOS /usr/bin/python3) does not have.
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
 exec python3 "$tmp/install_skills.py" --agent all --repos "$tmp/repos.yaml" "$@"

--- a/install/all/install.sh
+++ b/install/all/install.sh
@@ -13,9 +13,9 @@ if ! command -v python3 >/dev/null 2>&1; then
 fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-curl -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
-curl -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
 # catalog.json lets install_skills.py read the catalog without PyYAML,
 # which a stock python3 (e.g. macOS /usr/bin/python3) does not have.
-curl -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
 exec python3 "$tmp/install_skills.py" --agent all --repos "$tmp/repos.yaml" "$@"

--- a/install/antigravity/install.sh
+++ b/install/antigravity/install.sh
@@ -7,15 +7,16 @@
 # or --all to install a whole set.
 set -eu
 RAW="https://raw.githubusercontent.com/DevOpsAIguru123/awesome-agentic-devops/main"
+HTTPS_ONLY='=https'
 if ! command -v python3 >/dev/null 2>&1; then
   echo "Python 3 is required. Install it, then re-run." >&2
   exit 1
 fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
 # catalog.json lets install_skills.py read the catalog without PyYAML,
 # which a stock python3 (e.g. macOS /usr/bin/python3) does not have.
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
 exec python3 "$tmp/install_skills.py" --agent antigravity --repos "$tmp/repos.yaml" "$@"

--- a/install/antigravity/install.sh
+++ b/install/antigravity/install.sh
@@ -13,9 +13,9 @@ if ! command -v python3 >/dev/null 2>&1; then
 fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-curl -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
-curl -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
 # catalog.json lets install_skills.py read the catalog without PyYAML,
 # which a stock python3 (e.g. macOS /usr/bin/python3) does not have.
-curl -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
 exec python3 "$tmp/install_skills.py" --agent antigravity --repos "$tmp/repos.yaml" "$@"

--- a/install/claude-code/install.sh
+++ b/install/claude-code/install.sh
@@ -7,15 +7,16 @@
 # or --all to install a whole set.
 set -eu
 RAW="https://raw.githubusercontent.com/DevOpsAIguru123/awesome-agentic-devops/main"
+HTTPS_ONLY='=https'
 if ! command -v python3 >/dev/null 2>&1; then
   echo "Python 3 is required. Install it, then re-run." >&2
   exit 1
 fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
 # catalog.json lets install_skills.py read the catalog without PyYAML,
 # which a stock python3 (e.g. macOS /usr/bin/python3) does not have.
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
 exec python3 "$tmp/install_skills.py" --agent claude-code --repos "$tmp/repos.yaml" "$@"

--- a/install/claude-code/install.sh
+++ b/install/claude-code/install.sh
@@ -13,9 +13,9 @@ if ! command -v python3 >/dev/null 2>&1; then
 fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-curl -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
-curl -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
 # catalog.json lets install_skills.py read the catalog without PyYAML,
 # which a stock python3 (e.g. macOS /usr/bin/python3) does not have.
-curl -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
 exec python3 "$tmp/install_skills.py" --agent claude-code --repos "$tmp/repos.yaml" "$@"

--- a/install/codex/install.sh
+++ b/install/codex/install.sh
@@ -13,9 +13,9 @@ if ! command -v python3 >/dev/null 2>&1; then
 fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-curl -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
-curl -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
 # catalog.json lets install_skills.py read the catalog without PyYAML,
 # which a stock python3 (e.g. macOS /usr/bin/python3) does not have.
-curl -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
 exec python3 "$tmp/install_skills.py" --agent codex --repos "$tmp/repos.yaml" "$@"

--- a/install/codex/install.sh
+++ b/install/codex/install.sh
@@ -7,15 +7,16 @@
 # or --all to install a whole set.
 set -eu
 RAW="https://raw.githubusercontent.com/DevOpsAIguru123/awesome-agentic-devops/main"
+HTTPS_ONLY='=https'
 if ! command -v python3 >/dev/null 2>&1; then
   echo "Python 3 is required. Install it, then re-run." >&2
   exit 1
 fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
 # catalog.json lets install_skills.py read the catalog without PyYAML,
 # which a stock python3 (e.g. macOS /usr/bin/python3) does not have.
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
 exec python3 "$tmp/install_skills.py" --agent codex --repos "$tmp/repos.yaml" "$@"

--- a/install/cursor/install.sh
+++ b/install/cursor/install.sh
@@ -7,15 +7,16 @@
 # or --all to install a whole set.
 set -eu
 RAW="https://raw.githubusercontent.com/DevOpsAIguru123/awesome-agentic-devops/main"
+HTTPS_ONLY='=https'
 if ! command -v python3 >/dev/null 2>&1; then
   echo "Python 3 is required. Install it, then re-run." >&2
   exit 1
 fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
 # catalog.json lets install_skills.py read the catalog without PyYAML,
 # which a stock python3 (e.g. macOS /usr/bin/python3) does not have.
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
 exec python3 "$tmp/install_skills.py" --agent cursor --repos "$tmp/repos.yaml" "$@"

--- a/install/cursor/install.sh
+++ b/install/cursor/install.sh
@@ -13,9 +13,9 @@ if ! command -v python3 >/dev/null 2>&1; then
 fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-curl -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
-curl -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
 # catalog.json lets install_skills.py read the catalog without PyYAML,
 # which a stock python3 (e.g. macOS /usr/bin/python3) does not have.
-curl -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
 exec python3 "$tmp/install_skills.py" --agent cursor --repos "$tmp/repos.yaml" "$@"

--- a/install/vscode/install.sh
+++ b/install/vscode/install.sh
@@ -7,15 +7,16 @@
 # or --all to install a whole set.
 set -eu
 RAW="https://raw.githubusercontent.com/DevOpsAIguru123/awesome-agentic-devops/main"
+HTTPS_ONLY='=https'
 if ! command -v python3 >/dev/null 2>&1; then
   echo "Python 3 is required. Install it, then re-run." >&2
   exit 1
 fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
 # catalog.json lets install_skills.py read the catalog without PyYAML,
 # which a stock python3 (e.g. macOS /usr/bin/python3) does not have.
-curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
+curl --proto "$HTTPS_ONLY" --proto-redir "$HTTPS_ONLY" -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
 exec python3 "$tmp/install_skills.py" --agent vscode --repos "$tmp/repos.yaml" "$@"

--- a/install/vscode/install.sh
+++ b/install/vscode/install.sh
@@ -13,9 +13,9 @@ if ! command -v python3 >/dev/null 2>&1; then
 fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-curl -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
-curl -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/scripts/install_skills.py" -o "$tmp/install_skills.py"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/repos.yaml" -o "$tmp/repos.yaml"
 # catalog.json lets install_skills.py read the catalog without PyYAML,
 # which a stock python3 (e.g. macOS /usr/bin/python3) does not have.
-curl -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
+curl --proto '=https' --proto-redir '=https' -fsSL "$RAW/data/catalog.json" -o "$tmp/catalog.json"
 exec python3 "$tmp/install_skills.py" --agent vscode --repos "$tmp/repos.yaml" "$@"

--- a/scripts/audit_github_repos.py
+++ b/scripts/audit_github_repos.py
@@ -54,7 +54,7 @@ def resolve_cli_path(path: Path, root: Path | None = None) -> Path:
 
 
 def parse_github_repo(value: str) -> tuple[str, str]:
-    if value.startswith("http://") or value.startswith("https://"):
+    if value.startswith(("http://", "https://")):
         parsed = urlparse(value)
         if parsed.netloc.lower() != "github.com":
             raise ValueError(f"{value!r} is not a GitHub repo URL")
@@ -181,8 +181,15 @@ def build_summary(results: list[AuditResult]) -> dict[str, int]:
 
 
 def _markdown_row(result: AuditResult) -> str:
-    reachable = "skipped" if result.skipped else "yes" if result.reachable else "no"
-    archived = "yes" if result.archived else "no" if result.archived is False else ""
+    if result.skipped:
+        reachable = "skipped"
+    else:
+        reachable = "yes" if result.reachable else "no"
+
+    if result.archived is None:
+        archived = ""
+    else:
+        archived = "yes" if result.archived else "no"
     warnings = "; ".join(result.warnings) if result.warnings else result.error
     return (
         f"| {result.name} | {reachable} | {archived} | "

--- a/scripts/sync_readme_counts.py
+++ b/scripts/sync_readme_counts.py
@@ -20,7 +20,7 @@ README = ROOT / "README.md"
 REPOS_YAML = ROOT / "data" / "repos.yaml"
 
 COUNTS_PATTERN = re.compile(
-    r"\d+ entries organized into \d+ catalog sections"
+    r"[0-9]{1,9} entries organized into [0-9]{1,9} catalog sections"
 )
 
 

--- a/scripts/sync_readme_counts.py
+++ b/scripts/sync_readme_counts.py
@@ -20,7 +20,7 @@ README = ROOT / "README.md"
 REPOS_YAML = ROOT / "data" / "repos.yaml"
 
 COUNTS_PATTERN = re.compile(
-    r"[0-9]{1,9} entries organized into [0-9]{1,9} catalog sections"
+    r"\d{1,9} entries organized into \d{1,9} catalog sections"
 )
 
 

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -70,13 +70,17 @@ def test_rejects_missing_required_field():
 
 
 def test_rejects_invalid_action_level():
+    entries = [valid_entry(action_level="autonomous-apply")]
+
     with pytest.raises(ValidationError, match="invalid action_level"):
-        validate_entries([valid_entry(action_level="autonomous-apply")])
+        validate_entries(entries)
 
 
 def test_rejects_labels_that_are_not_a_list():
+    entries = [valid_entry(labels="🟡")]
+
     with pytest.raises(ValidationError, match="labels must be a list"):
-        validate_entries([valid_entry(labels="🟡")])
+        validate_entries(entries)
 
 
 def test_rejects_non_list_yaml(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,139 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "awesome-agentic-devops"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]


### PR DESCRIPTION
## Summary
- enforce HTTPS across installer downloads
- lock Python dependencies and use the lock in CI
- resolve Python maintainability and test findings
- configure GCS access logging in the Terraform sample

## Validation
- 66 tests passed
- shell syntax checks passed
- Terraform formatting passed
- uv lock consistency passed

This follows merged PR #63 and contains the medium-severity remediation that was committed after that PR merged.