### PR TITLE
test: reject duplicate catalog URLs

### DIFF
--- a/scripts/validate_repos_yaml.py
+++ b/scripts/validate_repos_yaml.py
@@ -95,6 +95,18 @@ def _validate_entry(entry: dict[str, Any], index: int) -> None:
             raise ValidationError(f"{name}: {field} must be a list")
 
 
+def _validate_unique_field(entries: list[dict[str, Any]], field: str) -> None:
+    seen: dict[Any, str] = {}
+    for index, entry in enumerate(entries):
+        value = entry[field]
+        name = _entry_name(entry, index)
+        if value in seen:
+            raise ValidationError(
+                f"{name}: duplicate {field} {value!r}; first used by {seen[value]}"
+            )
+        seen[value] = name
+
+
 def validate_entries(entries: Any) -> list[dict[str, Any]]:
     if not isinstance(entries, list):
         raise ValidationError("data/repos.yaml must contain a list of repo entries")
@@ -103,6 +115,9 @@ def validate_entries(entries: Any) -> list[dict[str, Any]]:
         if not isinstance(entry, dict):
             raise ValidationError(f"entry #{index + 1} must be a mapping")
         _validate_entry(entry, index)
+
+    _validate_unique_field(entries, "name")
+    _validate_unique_field(entries, "url")
 
     return entries
 

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -51,6 +51,13 @@ def test_seed_data_has_unique_repo_names():
     assert len(names) == len(set(names))
 
 
+def test_seed_data_has_unique_urls():
+    entries = validate_file(Path("data/repos.yaml"))
+    urls = [entry["url"] for entry in entries]
+
+    assert len(urls) == len(set(urls))
+
+
 @pytest.mark.parametrize("action_level", sorted(ALLOWED_ACTION_LEVELS))
 def test_accepts_allowed_action_levels(action_level):
     validate_entries([valid_entry(action_level=action_level)])
@@ -80,6 +87,26 @@ def test_rejects_labels_that_are_not_a_list():
     entries = [valid_entry(labels="prototype")]
 
     with pytest.raises(ValidationError, match="labels must be a list"):
+        validate_entries(entries)
+
+
+def test_rejects_duplicate_names():
+    entries = [
+        valid_entry(name="vendor/tool-a", url="https://github.com/vendor/tool-a"),
+        valid_entry(name="vendor/tool-a", url="https://github.com/vendor/tool-b"),
+    ]
+
+    with pytest.raises(ValidationError, match="duplicate name"):
+        validate_entries(entries)
+
+
+def test_rejects_duplicate_urls():
+    entries = [
+        valid_entry(name="vendor/tool-a", url="https://github.com/vendor/tool"),
+        valid_entry(name="vendor/tool-b", url="https://github.com/vendor/tool"),
+    ]
+
+    with pytest.raises(ValidationError, match="duplicate url"):
         validate_entries(entries)
 
 


### PR DESCRIPTION
## Summary

- Add catalog validator checks that reject duplicate name and url values.
- Add regression tests covering duplicate names, duplicate URLs, and current seed-data URL uniqueness.

## Validation

- python3 scripts/validate_repos_yaml.py
- python3 -m pytest -q (system Python lacked pytest)
- python3 -m venv .venv && . .venv/bin/activate && python -m pip install -e '.[dev]' && python -m pytest -q

Auto-generated by daily maintainer cron - 2026-07-26.