### PR TITLE
Add AgentServices — x402-paid API routing layer and MCP marketplace for DevOps agents

### DIFF
--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1172,6 +1172,27 @@
     - mcp
     - prototype
 
+- name: vbkotecha/agentservices-api
+  url: https://github.com/vbkotecha/agentservices-api
+  category: community-discovery
+  type: mcp-server
+  framework: MCP
+  primary_language: Python
+  cloud_provider: multi-cloud
+  use_cases:
+    - agent-api-routing
+    - paid-api-discovery
+    - x402-payment-integration
+  action_level: read-only
+  human_approval: unknown
+  evidence_tracing: none
+  maturity: production-adjacent
+  risk_notes: "AgentServices routes agent tool calls to paid data APIs via x402 micropayments; review API provider trust and cost controls before production use."
+  operator_note: "x402-paid API routing layer and MCP marketplace for AI agents — discover, route, and pay for 50+ data services."
+  labels:
+    - mcp
+    - prod
+
 - name: antonbabenko/terraform-skill
   url: https://github.com/antonbabenko/terraform-skill
   category: community-agent-skills


### PR DESCRIPTION
## What is AgentServices?

AgentServices is a **routing and discovery layer for agent APIs** — think OpenRouter for agent tools. It sits between the agent and external data APIs, handling:

- **Discovery** — 50+ data services (crypto, market intelligence, web search, portfolio analytics)
- **Routing** — MCP server interface ()
- **Payments** — x402 micropayment protocol for per-call billing
- **Provisioning** — npm SDK ()

## Why it fits here

DevOps and SRE agents increasingly need external data (market data, onchain state, web intelligence). AgentServices provides a single MCP endpoint where agents discover, route to, and pay for these APIs without per-provider integration work.

**MCP Server:** `to.agentservices/agentservices` (listed on MCP Registry)
**npm:** `@agentservices/client` v5.3.0
**Repo:** https://github.com/vbkotecha/agentservices-api
**Site:** https://agentservices.to

## Entry details

Added under `community-discovery` category as an MCP server and API routing layer. Scored as `mcp` + `prod` based on production deployment status.