### PR TITLE
test: harden catalog schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ documented here. The format is based on
 
 ### Changed
 
+- **Hardened catalog schema validation.** Required string fields now reject blank
+  values, and `labels` / `use_cases` must contain at least one non-empty string
+  item so incomplete catalog rows fail locally before reaching README generation
+  or CI.
 - **Replaced the emoji evaluation labels with text badges.** The six glyphs
   (🟢 🟡 🔵 🛡️ 📊 ⚠️) are now readable tokens — `prod`, `prototype`, `mcp`,
   `approval`, `evidence`, `write` — across the legend, all catalog rows,

--- a/scripts/validate_repos_yaml.py
+++ b/scripts/validate_repos_yaml.py
@@ -37,6 +37,18 @@ ALLOWED_MATURITY = {
 }
 ALLOWED_EVIDENCE_TRACING = {"none", "partial", "yes", "unknown"}
 ALLOWED_HUMAN_APPROVAL = {True, False, "unknown"}
+STRING_FIELDS = (
+    "name",
+    "url",
+    "category",
+    "type",
+    "framework",
+    "primary_language",
+    "cloud_provider",
+    "risk_notes",
+    "operator_note",
+)
+LIST_FIELDS = ("labels", "use_cases")
 
 
 class ValidationError(Exception):
@@ -77,9 +89,28 @@ def _validate_choice(name: str, field: str, value: Any, allowed: set[Any]) -> No
         )
 
 
+def _validate_non_empty_string(name: str, field: str, value: Any) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{name}: {field} must be a non-empty string")
+
+
+def _validate_string_list(name: str, field: str, value: Any) -> None:
+    if not isinstance(value, list):
+        raise ValidationError(f"{name}: {field} must be a list")
+    if not value:
+        raise ValidationError(f"{name}: {field} must contain at least one item")
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise ValidationError(f"{name}: {field} items must be non-empty strings")
+
+
 def _validate_entry(entry: dict[str, Any], index: int) -> None:
     name = _entry_name(entry, index)
     _require_fields(entry, name)
+    for field in STRING_FIELDS:
+        _validate_non_empty_string(name, field, entry[field])
+    for field in LIST_FIELDS:
+        _validate_string_list(name, field, entry[field])
     _validate_choice(name, "action_level", entry["action_level"], ALLOWED_ACTION_LEVELS)
     _validate_choice(name, "maturity", entry["maturity"], ALLOWED_MATURITY)
     _validate_choice(
@@ -90,9 +121,6 @@ def _validate_entry(entry: dict[str, Any], index: int) -> None:
     )
     if entry["human_approval"] not in ALLOWED_HUMAN_APPROVAL:
         raise ValidationError(f"{name}: human_approval must be true, false, or unknown")
-    for field in ("labels", "use_cases"):
-        if not isinstance(entry[field], list):
-            raise ValidationError(f"{name}: {field} must be a list")
 
 
 def _validate_unique_field(entries: list[dict[str, Any]], field: str) -> None:

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -90,6 +90,27 @@ def test_rejects_labels_that_are_not_a_list():
         validate_entries(entries)
 
 
+def test_rejects_empty_string_fields():
+    entries = [valid_entry(operator_note="   ")]
+
+    with pytest.raises(ValidationError, match="operator_note must be a non-empty string"):
+        validate_entries(entries)
+
+
+def test_rejects_empty_list_fields():
+    entries = [valid_entry(use_cases=[])]
+
+    with pytest.raises(ValidationError, match="use_cases must contain at least one item"):
+        validate_entries(entries)
+
+
+def test_rejects_blank_list_items():
+    entries = [valid_entry(labels=["official", ""])]
+
+    with pytest.raises(ValidationError, match="labels items must be non-empty strings"):
+        validate_entries(entries)
+
+
 def test_rejects_duplicate_names():
     entries = [
         valid_entry(name="vendor/tool-a", url="https://github.com/vendor/tool-a"),


### PR DESCRIPTION
## Summary

- Harden catalog schema validation so required string fields cannot be blank.
- Require labels and use_cases to contain at least one non-empty string item.
- Add regression tests and update the changelog.

## Validation

- `. .venv/bin/activate && python scripts/validate_repos_yaml.py`
- `. .venv/bin/activate && python -m pytest -q`

Auto-generated by daily maintainer cron for 2026-07-28.
