### PR TITLE
test: require https catalog urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ documented here. The format is based on
   values, and `labels` / `use_cases` must contain at least one non-empty string
   item so incomplete catalog rows fail locally before reaching README generation
   or CI.
+- **Hardened catalog URL validation.** Catalog entries now require absolute
+  `https://` URLs, blocking accidental relative links, bare hostnames, and
+  insecure `http://` sources from entering the operator index.
 - **Replaced the emoji evaluation labels with text badges.** The six glyphs
   (🟢 🟡 🔵 🛡️ 📊 ⚠️) are now readable tokens — `prod`, `prototype`, `mcp`,
   `approval`, `evidence`, `write` — across the legend, all catalog rows,

--- a/scripts/validate_repos_yaml.py
+++ b/scripts/validate_repos_yaml.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import yaml
 
@@ -104,6 +105,12 @@ def _validate_string_list(name: str, field: str, value: Any) -> None:
             raise ValidationError(f"{name}: {field} items must be non-empty strings")
 
 
+def _validate_https_url(name: str, value: str) -> None:
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ValidationError(f"{name}: url must be an absolute https URL")
+
+
 def _validate_entry(entry: dict[str, Any], index: int) -> None:
     name = _entry_name(entry, index)
     _require_fields(entry, name)
@@ -111,6 +118,7 @@ def _validate_entry(entry: dict[str, Any], index: int) -> None:
         _validate_non_empty_string(name, field, entry[field])
     for field in LIST_FIELDS:
         _validate_string_list(name, field, entry[field])
+    _validate_https_url(name, entry["url"])
     _validate_choice(name, "action_level", entry["action_level"], ALLOWED_ACTION_LEVELS)
     _validate_choice(name, "maturity", entry["maturity"], ALLOWED_MATURITY)
     _validate_choice(

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -97,6 +97,21 @@ def test_rejects_empty_string_fields():
         validate_entries(entries)
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://github.com/vendor/tool",
+        "github.com/vendor/tool",
+        "/docs/tool",
+    ],
+)
+def test_rejects_urls_that_are_not_absolute_https(url):
+    entries = [valid_entry(url=url)]
+
+    with pytest.raises(ValidationError, match="url must be an absolute https URL"):
+        validate_entries(entries)
+
+
 def test_rejects_empty_list_fields():
     entries = [valid_entry(use_cases=[])]
 


### PR DESCRIPTION
## Summary

- require catalog entry URLs to be absolute https URLs in validate_repos_yaml.py
- add regression coverage for http, bare-host, and relative URL inputs
- document the validator hardening in CHANGELOG.md

## Validation

- python3 scripts/validate_repos_yaml.py
- . .venv/bin/activate && python scripts/validate_repos_yaml.py && python -m pytest -q

Auto-generated by daily cron - 2026-07-29