### PR TITLE
docs: expand agent scorecard safety review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ documented here. The format is based on
 - **Expanded the agent scorecard safety review.** The reusable scorecard now
   captures least-privilege credential scope, no-secret-in-context checks,
   redaction expectations, dry-run/preview commands, approval records, and audit
-  artifacts before recommending production-adjacent use.
+  artifacts, plus an explicit production-readiness decision, before recommending
+  production-adjacent use.
 - **Hardened catalog schema validation.** Required string fields now reject blank
   values, and `labels` / `use_cases` must contain at least one non-empty string
   item so incomplete catalog rows fail locally before reaching README generation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ documented here. The format is based on
 
 ### Changed
 
+- **Expanded the agent scorecard safety review.** The reusable scorecard now
+  captures least-privilege credential scope, no-secret-in-context checks,
+  redaction expectations, dry-run/preview commands, approval records, and audit
+  artifacts before recommending production-adjacent use.
 - **Hardened catalog schema validation.** Required string fields now reject blank
   values, and `labels` / `use_cases` must contain at least one non-empty string
   item so incomplete catalog rows fail locally before reaching README generation

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -50,3 +50,4 @@ Do not paste secrets, cloud credentials, kubeconfigs, private keys, tokens, or s
 - Write-capable entries must carry the `write` label unless the write surface is clearly isolated.
 - Approval-aware entries should carry `approval` only when a meaningful approval or safety mechanism is documented or strongly evident.
 - Evidence-aware entries should carry `evidence` only when there is a trace, eval, audit, cited evidence, or equivalent mechanism.
+- Deep reviews should use the [agent scorecard template](../templates/agent-scorecard.md) to capture credential boundaries, no-secret-in-context controls, dry-run commands, approval evidence, and audit artifacts before recommending production-adjacent use.

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -50,4 +50,4 @@ Do not paste secrets, cloud credentials, kubeconfigs, private keys, tokens, or s
 - Write-capable entries must carry the `write` label unless the write surface is clearly isolated.
 - Approval-aware entries should carry `approval` only when a meaningful approval or safety mechanism is documented or strongly evident.
 - Evidence-aware entries should carry `evidence` only when there is a trace, eval, audit, cited evidence, or equivalent mechanism.
-- Deep reviews should use the [agent scorecard template](../templates/agent-scorecard.md) to capture credential boundaries, no-secret-in-context controls, dry-run commands, approval evidence, and audit artifacts before recommending production-adjacent use.
+- Deep reviews should use the [agent scorecard template](../templates/agent-scorecard.md) to capture credential boundaries, no-secret-in-context controls, dry-run commands, approval evidence, audit artifacts, and an explicit production-readiness decision before recommending production-adjacent use.

--- a/templates/agent-scorecard.md
+++ b/templates/agent-scorecard.md
@@ -86,3 +86,10 @@ What real DevOps, Cloud, SRE, Kubernetes, Terraform, CI/CD, or platform engineer
 - Labels:
 - Operator recommendation:
 - Next action:
+
+## Production-readiness decision
+
+- Safe to run with read-only credentials:
+- Safe to recommend proposal-mode automation:
+- Safe to enable write-capable tools after approval:
+- Required blockers before production use:

--- a/templates/agent-scorecard.md
+++ b/templates/agent-scorecard.md
@@ -26,15 +26,27 @@ What real DevOps, Cloud, SRE, Kubernetes, Terraform, CI/CD, or platform engineer
 - Action level: `read-only` / `proposal` / `write-capable` / `unknown`
 - Mutating operations:
 - Production blast radius:
-- Credential requirements:
+- Default mode before credentials are added:
+- Safe local or demo mode available:
+
+## Credential and context boundary
+
+- Credential type required: read-only token / scoped write token / cloud role / kubeconfig / none
+- Least-privilege scope to grant:
+- Token rotation or expiry guidance:
+- Secrets excluded from model context:
+- Sensitive logs/artifacts redacted before analysis:
+- Separate read and write credentials:
 
 ## Safety gates
 
 - Human approval:
+- Approval recorded in:
 - Policy checks:
-- Dry-run support:
+- Dry-run or preview command:
 - Rollback guidance:
-- Refusal behavior:
+- Refusal behavior for destructive/high-risk operations:
+- Write tools disabled by default or gated by config:
 
 ## Evidence/tracing
 
@@ -43,6 +55,8 @@ What real DevOps, Cloud, SRE, Kubernetes, Terraform, CI/CD, or platform engineer
 - Stores traces:
 - Supports evals:
 - Audit artifacts:
+- Links approval record to action/output:
+- Captures exact tool inputs after secret redaction:
 
 ## Setup friction
 


### PR DESCRIPTION
## Summary

- expand the reusable agent scorecard with credential/context-boundary prompts
- require reviewers to capture no-secret-in-context, redaction, least-privilege, and credential-separation notes
- make approval evidence, dry-run/preview commands, write-tool gating, and audit artifacts explicit
- link the safety model's minimum bar to the scorecard for deeper production-adjacent reviews

## Validation

- python3 scripts/validate_repos_yaml.py
- python3 scripts/sync_readme_counts.py --check
- /Users/tuximac/projects/awesome-agentic-devops/.venv/bin/python -m pytest -q
- git diff --check

## Risk

Low. Documentation/template-only change; no catalog entry, workflow, or executable behavior changes.

Auto-generated by daily maintainer cron on 2026-07-31.
