### PR TITLE
test: validate write label consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ documented here. The format is based on
 - **Hardened catalog URL validation.** Catalog entries now require absolute
   `https://` URLs, blocking accidental relative links, bare hostnames, and
   insecure `http://` sources from entering the operator index.
+- **Hardened write-capability label validation.** The catalog validator now
+  rejects entries where `action_level: write-capable` and the README-facing
+  `write` label drift apart, keeping blast-radius warnings consistent between
+  `data/repos.yaml` and generated catalog tables.
 - **Replaced the emoji evaluation labels with text badges.** The six glyphs
   (🟢 🟡 🔵 🛡️ 📊 ⚠️) are now readable tokens — `prod`, `prototype`, `mcp`,
   `approval`, `evidence`, `write` — across the legend, all catalog rows,

--- a/scripts/validate_repos_yaml.py
+++ b/scripts/validate_repos_yaml.py
@@ -143,6 +143,18 @@ def _validate_unique_field(entries: list[dict[str, Any]], field: str) -> None:
         seen[value] = name
 
 
+def _validate_write_label_consistency(entry: dict[str, Any], index: int) -> None:
+    name = _entry_name(entry, index)
+    labels = set(entry["labels"])
+    is_write_capable = entry["action_level"] == "write-capable"
+    has_write_label = "write" in labels
+
+    if is_write_capable and not has_write_label:
+        raise ValidationError(f"{name}: write-capable entries must include write label")
+    if has_write_label and not is_write_capable:
+        raise ValidationError(f"{name}: write label requires action_level write-capable")
+
+
 def validate_entries(entries: Any) -> list[dict[str, Any]]:
     if not isinstance(entries, list):
         raise ValidationError("data/repos.yaml must contain a list of repo entries")
@@ -151,6 +163,7 @@ def validate_entries(entries: Any) -> list[dict[str, Any]]:
         if not isinstance(entry, dict):
             raise ValidationError(f"entry #{index + 1} must be a mapping")
         _validate_entry(entry, index)
+        _validate_write_label_consistency(entry, index)
 
     _validate_unique_field(entries, "name")
     _validate_unique_field(entries, "url")

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -60,7 +60,8 @@ def test_seed_data_has_unique_urls():
 
 @pytest.mark.parametrize("action_level", sorted(ALLOWED_ACTION_LEVELS))
 def test_accepts_allowed_action_levels(action_level):
-    validate_entries([valid_entry(action_level=action_level)])
+    labels = ["prototype", "write"] if action_level == "write-capable" else ["prototype"]
+    validate_entries([valid_entry(action_level=action_level, labels=labels)])
 
 
 @pytest.mark.parametrize("maturity", sorted(ALLOWED_MATURITY))
@@ -123,6 +124,20 @@ def test_rejects_blank_list_items():
     entries = [valid_entry(labels=["official", ""])]
 
     with pytest.raises(ValidationError, match="labels items must be non-empty strings"):
+        validate_entries(entries)
+
+
+def test_write_capable_entries_require_write_label():
+    entries = [valid_entry(action_level="write-capable", labels=["prototype", "approval"])]
+
+    with pytest.raises(ValidationError, match="must include write label"):
+        validate_entries(entries)
+
+
+def test_write_label_requires_write_capable_action_level():
+    entries = [valid_entry(action_level="proposal", labels=["prototype", "write"])]
+
+    with pytest.raises(ValidationError, match="requires action_level write-capable"):
         validate_entries(entries)
 
 


### PR DESCRIPTION
## Summary

- add validator enforcement that write-capable catalog entries include the write label
- reject README-facing write labels on entries that are not marked write-capable
- add regression tests and changelog coverage for the safety-label invariant

## Validation

- python3 scripts/validate_repos_yaml.py
- python3 scripts/sync_readme_counts.py --check
- /Users/tuximac/projects/awesome-agentic-devops/.venv/bin/python -m pytest -q
- git diff --check

## Risk

Low. Validation/test-only hardening plus changelog note; no catalog entry or README table changes.

Auto-generated by daily maintainer cron on 2026-08-01.