### PR TITLE
docs: expand PR safety checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,13 +11,21 @@
 - [ ] Labels match the observed behavior, not marketing claims.
 - [ ] `data/repos.yaml` and `README.md` are both updated.
 
+## Safety checklist
+
+- [ ] No secrets, tokens, kubeconfigs, customer data, or private logs are included in the PR, fixtures, screenshots, or generated artifacts.
+- [ ] Write-capable tools document approval gates, dry-run or preview behavior, audit/evidence output, and rollback expectations.
+- [ ] Credential guidance uses least privilege and separates read-only credentials from write-capable credentials.
+- [ ] Any new telemetry, hosted service, or external API dependency is disclosed with operator-facing risk notes.
+
 ## Validation
 
 ```bash
 python scripts/validate_repos_yaml.py
-pytest -q
+python scripts/sync_readme_counts.py --check
+python -m pytest -q
 python scripts/run_mock_eval_scenarios.py
 python scripts/audit_github_repos.py --workers 12 --fail-on-unreachable
 ```
 
-- [ ] All of the above pass locally.
+- [ ] Relevant commands above pass locally, or this PR explains why a command is not applicable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ documented here. The format is based on
 
 ### Changed
 
+- **Expanded pull request safety checklist.** The PR template now asks
+  contributors to confirm no-secret-in-context handling, least-privilege
+  credential guidance, approval gates, dry-run/preview behavior, audit evidence,
+  rollback expectations, and telemetry/external API disclosure before review.
 - **Hardened catalog schema validation.** Required string fields now reject blank
   values, and `labels` / `use_cases` must contain at least one non-empty string
   item so incomplete catalog rows fail locally before reaching README generation


### PR DESCRIPTION
## Summary

- add a PR-template safety checklist for no-secret-in-context review, least-privilege credentials, approval gates, dry-run or preview behavior, audit evidence, rollback expectations, and telemetry disclosure
- refresh the template validation commands to include README count checks and `python -m pytest -q`
- document the contributor-safety checklist update in CHANGELOG.md

## Validation

- python3 scripts/validate_repos_yaml.py
- python3 scripts/sync_readme_counts.py --check
- /Users/tuximac/projects/awesome-agentic-devops/.venv/bin/python -m pytest -q
- git diff --check

## Risk

Low. Documentation/template-only change; no catalog entries, README tables, or workflows changed.

Auto-generated by daily maintainer cron on 2026-08-02.