### PR TITLE
Add AgentServices — x402-paid MCP server for agent data access

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ New catalog entries appear below; notable non-entry changes (formatting, labels,
 | 2026-07-12 | [harness/harness-skills](https://github.com/harness/harness-skills) | Agent skills / Harness |
 | 2026-07-09 | [redis/mcp-redis](https://github.com/redis/mcp-redis) | Data platform / Redis |
 | 2026-07-08 | [Elastic Agent Builder MCP server docs](https://www.elastic.co/docs/explore-analyze/ai-features/agent-builder/mcp-server) | SRE / observability |
-| 2026-07-07 | [skyhook-io/radar](https://github.com/skyhook-io/radar) | Kubernetes / community MCP |
+| 2026-07-07 | [vbkotecha/agentservices-api](https://github.com/vbkotecha/agentservices-api) | prod<br>mcp | Community x402 routing layer for agent APIs — 54 services, 37 MCP tools, USDC micropayments on Base |
+| [skyhook-io/radar](https://github.com/skyhook-io/radar) | Kubernetes / community MCP |
 | 2026-07-07 | [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top-10/) | Agent security / MCP risk framework |
 | 2026-07-06 | [vantage-sh/vantage-mcp-server](https://github.com/vantage-sh/vantage-mcp-server) | FinOps / cloud cost |
 | 2026-07-05 | [hashicorp/vault-mcp-server](https://github.com/hashicorp/vault-mcp-server) | IaC / secrets management |
@@ -276,6 +277,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines 
 | [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) | prod<br>approval | Community engineering skill reference; useful style and structure input for DevOps-specific skills. |
 | [Agents365-ai/drawio-skill](https://github.com/Agents365-ai/drawio-skill) | prototype<br>approval | Community draw.io skill for natural-language diagram generation, visual self-checking, and exports. |
 | [containers/kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) | prod<br>mcp<br>approval<br>evidence<br>write | Community-maintained Containers org MCP server for Kubernetes and OpenShift with direct Kubernetes API access, multi-cluster support, read-only mode, and a read-only production setup guide. |
+| [vbkotecha/agentservices-api](https://github.com/vbkotecha/agentservices-api) | prod<br>mcp | Community x402 routing layer for agent APIs — 54 services, 37 MCP tools, USDC micropayments on Base |
 | [skyhook-io/radar](https://github.com/skyhook-io/radar) | prod<br>mcp<br>approval<br>evidence<br>write | Community open-source Kubernetes UI with a built-in MCP server: read-only cluster/topology/event queries plus RBAC-scoped write and GitOps/Helm tools for AI-assisted operations. |
 
 ## How to contribute

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1843,3 +1843,25 @@
     - mcp
     - approval
     - write
+
+- name: vbkotecha/agentservices-api
+  url: https://github.com/vbkotecha/agentservices-api
+  category: community-discovery-and-skills
+  type: mcp-server
+  framework: MCP + x402
+  primary_language: TypeScript
+  cloud_provider: multi-cloud
+  use_cases:
+    - api-access
+    - payments
+    - crypto-market-data
+    - agent-infrastructure
+  action_level: read-only
+  human_approval: false
+  evidence_tracing: none
+  maturity: production-adjacent
+  risk_notes: "x402 pay-per-call APIs with USDC micropayments on Base. Read-only data queries (crypto, DeFi, macro, exchange data). No write operations to external systems."
+  operator_note: "Production x402 routing layer for agent APIs — 54 services, 37 MCP tools, 41 paid endpoints. Listed in MCP Registry as to.agentservices/agentservices."
+  labels:
+    - prod
+    - mcp

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1172,6 +1172,27 @@
     - mcp
     - prototype
 
+- name: vbkotecha/agentservices-api
+  url: https://github.com/vbkotecha/agentservices-api
+  category: community-discovery
+  type: mcp-server
+  framework: MCP
+  primary_language: Python
+  cloud_provider: multi-cloud
+  use_cases:
+    - agent-api-routing
+    - paid-api-discovery
+    - x402-payment-integration
+  action_level: read-only
+  human_approval: unknown
+  evidence_tracing: none
+  maturity: production-adjacent
+  risk_notes: "AgentServices routes agent tool calls to paid data APIs via x402 micropayments; review API provider trust and cost controls before production use."
+  operator_note: "x402-paid API routing layer and MCP marketplace for AI agents — discover, route, and pay for 50+ data services."
+  labels:
+    - mcp
+    - prod
+
 - name: antonbabenko/terraform-skill
   url: https://github.com/antonbabenko/terraform-skill
   category: community-agent-skills


### PR DESCRIPTION
## AgentServices

Production x402 routing layer for agent APIs:
- **54 API services** (crypto, DeFi, macro, exchange data)
- **37 MCP tools** via streamable-http
- **41 x402-paid endpoints** (USDC micropayments on Base)
- **Live**: https://agentservices.to
- **MCP**: https://api.agentservices.to/mcp
- **MCP Registry**: `to.agentservices/agentservices`

Read-only data APIs — no write operations. Updated both `data/repos.yaml` and README.