### PR TITLE
test: validate catalog categories and types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,10 @@ documented here. The format is based on
   `https://` URLs, blocking accidental relative links, bare hostnames, and
   insecure `http://` sources from entering the operator index.
 - **Hardened catalog category validation.** Catalog entries must use one of the
-  curated category slugs, preventing README/YAML drift from typos or new sections
-  that lack matching tests and public documentation.
+  curated category slugs, and tests now require the validator allowlist to stay
+  synchronized with the categories currently used in `data/repos.yaml`, preventing
+  README/YAML drift from typos or new sections that lack matching tests and
+  public documentation.
 - **Hardened write-capability label validation.** The catalog validator now
   rejects entries where `action_level: write-capable` and the README-facing
   `write` label drift apart, keeping blast-radius warnings consistent between

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ documented here. The format is based on
 - **Hardened catalog URL validation.** Catalog entries now require absolute
   `https://` URLs, blocking accidental relative links, bare hostnames, and
   insecure `http://` sources from entering the operator index.
+- **Hardened catalog category validation.** Catalog entries must use one of the
+  curated category slugs, preventing README/YAML drift from typos or new sections
+  that lack matching tests and public documentation.
 - **Hardened write-capability label validation.** The catalog validator now
   rejects entries where `action_level: write-capable` and the README-facing
   `write` label drift apart, keeping blast-radius warnings consistent between

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ documented here. The format is based on
   synchronized with the categories currently used in `data/repos.yaml`, preventing
   README/YAML drift from typos or new sections that lack matching tests and
   public documentation.
+- **Hardened catalog type validation.** Catalog entries must use one of the
+  curated artifact kinds, and tests now require the validator allowlist to stay
+  synchronized with the `type` values currently used in `data/repos.yaml`,
+  preventing ambiguous or misspelled tool-surface metadata.
 - **Hardened write-capability label validation.** The catalog validator now
   rejects entries where `action_level: write-capable` and the README-facing
   `write` label drift apart, keeping blast-radius warnings consistent between

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Thanks for helping make this a practical operator-grade index instead of a hype 
 
 - The repo URL is public and reachable.
 - The entry has a specific category.
+- The `category` value is one of the existing catalog slugs validated by `scripts/validate_repos_yaml.py`; add a new slug only when you are also adding the matching README section and tests.
 - The `risk_notes` field explains what could go wrong.
 - The `operator_note` field explains why an infrastructure operator should care.
 - Labels match the observed behavior, not marketing claims.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ Thanks for helping make this a practical operator-grade index instead of a hype 
 - The repo URL is public and reachable.
 - The entry has a specific category.
 - The `category` value is one of the existing catalog slugs validated by `scripts/validate_repos_yaml.py`; add a new slug only when you are also adding the matching README section and tests.
+- The `type` value uses one of the validator-backed artifact kinds, such as `mcp-server`, `hosted-mcp-server`, `documentation`, `sdk`, `skill`, or `skill-library`; add a new kind only when the existing set cannot describe the artifact clearly.
 - The `risk_notes` field explains what could go wrong.
 - The `operator_note` field explains why an infrastructure operator should care.
 - Labels match the observed behavior, not marketing claims.

--- a/scripts/validate_repos_yaml.py
+++ b/scripts/validate_repos_yaml.py
@@ -55,6 +55,31 @@ ALLOWED_CATEGORIES = {
     "official-security-mcp-servers",
     "official-sre-mcp-servers",
 }
+ALLOWED_TYPES = {
+    "agent-framework",
+    "agent-plugin",
+    "agent-security-scanner",
+    "agent-template",
+    "agent-toolkit",
+    "curated-list",
+    "documentation",
+    "hosted-mcp-server",
+    "mcp-operator",
+    "mcp-plugin",
+    "mcp-registry",
+    "mcp-server",
+    "mcp-server-catalog",
+    "mcp-server-collection",
+    "mcp-server-plugin",
+    "reference-architecture",
+    "reference-implementations",
+    "registry",
+    "sdk",
+    "security-guidance",
+    "security-tool",
+    "skill",
+    "skill-library",
+}
 ALLOWED_MATURITY = {
     "production-adjacent",
     "active-oss",
@@ -147,6 +172,7 @@ def _validate_entry(entry: dict[str, Any], index: int) -> None:
         _validate_string_list(name, field, entry[field])
     _validate_https_url(name, entry["url"])
     _validate_choice(name, "category", entry["category"], ALLOWED_CATEGORIES)
+    _validate_choice(name, "type", entry["type"], ALLOWED_TYPES)
     _validate_choice(name, "action_level", entry["action_level"], ALLOWED_ACTION_LEVELS)
     _validate_choice(name, "maturity", entry["maturity"], ALLOWED_MATURITY)
     _validate_choice(

--- a/scripts/validate_repos_yaml.py
+++ b/scripts/validate_repos_yaml.py
@@ -28,6 +28,33 @@ REQUIRED_FIELDS = (
 )
 
 ALLOWED_ACTION_LEVELS = {"read-only", "proposal", "write-capable", "unknown"}
+ALLOWED_CATEGORIES = {
+    "community-agent-skills",
+    "community-discovery",
+    "community-mcp-servers",
+    "official-agent-frameworks",
+    "official-agent-security-tools",
+    "official-agent-skills",
+    "official-browser-automation-mcp-servers",
+    "official-ci-cd-mcp-servers",
+    "official-cloud-agent-toolkits",
+    "official-cloud-mcp-servers",
+    "official-cloud-security-mcp-servers",
+    "official-cloudops-agent-samples",
+    "official-data-platform-mcp-servers",
+    "official-devops-mcp-platforms",
+    "official-devops-mcp-servers",
+    "official-diagramming-mcp-tools",
+    "official-finops-mcp-servers",
+    "official-gitops-mcp-servers",
+    "official-iac-mcp-servers",
+    "official-mcp-reference-implementations",
+    "official-mcp-registry",
+    "official-mcp-sdks",
+    "official-platform-agent-toolkits",
+    "official-security-mcp-servers",
+    "official-sre-mcp-servers",
+}
 ALLOWED_MATURITY = {
     "production-adjacent",
     "active-oss",
@@ -119,6 +146,7 @@ def _validate_entry(entry: dict[str, Any], index: int) -> None:
     for field in LIST_FIELDS:
         _validate_string_list(name, field, entry[field])
     _validate_https_url(name, entry["url"])
+    _validate_choice(name, "category", entry["category"], ALLOWED_CATEGORIES)
     _validate_choice(name, "action_level", entry["action_level"], ALLOWED_ACTION_LEVELS)
     _validate_choice(name, "maturity", entry["maturity"], ALLOWED_MATURITY)
     _validate_choice(

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -5,6 +5,7 @@ import yaml
 
 from scripts.validate_repos_yaml import (
     ALLOWED_ACTION_LEVELS,
+    ALLOWED_CATEGORIES,
     ALLOWED_MATURITY,
     REQUIRED_FIELDS,
     ValidationError,
@@ -18,7 +19,7 @@ def valid_entry(**overrides):
     entry = {
         "name": "antonbabenko/terraform-skill",
         "url": "https://github.com/antonbabenko/terraform-skill",
-        "category": "terraform-iac-agents",
+        "category": "official-iac-mcp-servers",
         "type": "agent",
         "framework": "unknown",
         "primary_language": "Python",
@@ -64,6 +65,11 @@ def test_accepts_allowed_action_levels(action_level):
     validate_entries([valid_entry(action_level=action_level, labels=labels)])
 
 
+@pytest.mark.parametrize("category", sorted(ALLOWED_CATEGORIES))
+def test_accepts_allowed_categories(category):
+    validate_entries([valid_entry(category=category)])
+
+
 @pytest.mark.parametrize("maturity", sorted(ALLOWED_MATURITY))
 def test_accepts_allowed_maturity_values(maturity):
     validate_entries([valid_entry(maturity=maturity)])
@@ -81,6 +87,13 @@ def test_rejects_invalid_action_level():
     entries = [valid_entry(action_level="autonomous-apply")]
 
     with pytest.raises(ValidationError, match="invalid action_level"):
+        validate_entries(entries)
+
+
+def test_rejects_unknown_category():
+    entries = [valid_entry(category="official-cloud-mcp-server")]
+
+    with pytest.raises(ValidationError, match="invalid category"):
         validate_entries(entries)
 
 

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -7,6 +7,7 @@ from scripts.validate_repos_yaml import (
     ALLOWED_ACTION_LEVELS,
     ALLOWED_CATEGORIES,
     ALLOWED_MATURITY,
+    ALLOWED_TYPES,
     REQUIRED_FIELDS,
     ValidationError,
     resolve_cli_path,
@@ -20,7 +21,7 @@ def valid_entry(**overrides):
         "name": "antonbabenko/terraform-skill",
         "url": "https://github.com/antonbabenko/terraform-skill",
         "category": "official-iac-mcp-servers",
-        "type": "agent",
+        "type": "mcp-server",
         "framework": "unknown",
         "primary_language": "Python",
         "cloud_provider": "multi-cloud",
@@ -66,6 +67,13 @@ def test_seed_categories_match_validator_allowlist():
     assert categories == ALLOWED_CATEGORIES
 
 
+def test_seed_types_match_validator_allowlist():
+    entries = validate_file(Path("data/repos.yaml"))
+    entry_types = {entry["type"] for entry in entries}
+
+    assert entry_types == ALLOWED_TYPES
+
+
 @pytest.mark.parametrize("action_level", sorted(ALLOWED_ACTION_LEVELS))
 def test_accepts_allowed_action_levels(action_level):
     labels = ["prototype", "write"] if action_level == "write-capable" else ["prototype"]
@@ -75,6 +83,11 @@ def test_accepts_allowed_action_levels(action_level):
 @pytest.mark.parametrize("category", sorted(ALLOWED_CATEGORIES))
 def test_accepts_allowed_categories(category):
     validate_entries([valid_entry(category=category)])
+
+
+@pytest.mark.parametrize("entry_type", sorted(ALLOWED_TYPES))
+def test_accepts_allowed_types(entry_type):
+    validate_entries([valid_entry(type=entry_type)])
 
 
 @pytest.mark.parametrize("maturity", sorted(ALLOWED_MATURITY))
@@ -101,6 +114,13 @@ def test_rejects_unknown_category():
     entries = [valid_entry(category="official-cloud-mcp-server")]
 
     with pytest.raises(ValidationError, match="invalid category"):
+        validate_entries(entries)
+
+
+def test_rejects_unknown_type():
+    entries = [valid_entry(type="mcp-service")]
+
+    with pytest.raises(ValidationError, match="invalid type"):
         validate_entries(entries)
 
 

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -59,6 +59,13 @@ def test_seed_data_has_unique_urls():
     assert len(urls) == len(set(urls))
 
 
+def test_seed_categories_match_validator_allowlist():
+    entries = validate_file(Path("data/repos.yaml"))
+    categories = {entry["category"] for entry in entries}
+
+    assert categories == ALLOWED_CATEGORIES
+
+
 @pytest.mark.parametrize("action_level", sorted(ALLOWED_ACTION_LEVELS))
 def test_accepts_allowed_action_levels(action_level):
     labels = ["prototype", "write"] if action_level == "write-capable" else ["prototype"]


### PR DESCRIPTION
## Summary

- add an explicit allowed category set for data/repos.yaml validation
- add an explicit allowed type set for catalog artifact kinds
- reject category/type typos before they drift into README/catalog sections
- add regression coverage for current categories/types, unknown-value failures, and validator allowlist synchronization with data/repos.yaml
- document category slug and type expectations for contributors and record the hardening in the changelog

## Validation

- python3 scripts/validate_repos_yaml.py
- python3 scripts/sync_readme_counts.py --check
- python3 scripts/sync_catalog_json.py --check
- /Users/tuximac/projects/awesome-agentic-devops/.venv/bin/python -m pytest -q
- git diff --check

## Risk

Low. Validator, tests, and docs only; no catalog entries or workflow files changed.

Updated by daily maintainer cron on 2026-08-04.