### PR TITLE
Add OutageDeck for third-party outage triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated, **official-first** catalog of MCP servers, agent skills, AI agents, f
 
 Most agent lists stop at discovery. This one is built for operators:
 
-- **Official-first, community-inclusive** — 79 entries organized into 15 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
+- **Official-first, community-inclusive** — 80 entries organized into 15 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
 - **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
 - **Audited by CI** — GitHub repository entries are checked weekly for reachability and archived status; non-GitHub documentation links are outside this automated check and require curator review.
 - **Installable, not just readable** — [one command](#install-skills-into-your-coding-agent) installs hundreds of skills from cataloged Google, Microsoft, Azure, Azure DevOps, and Harness sources — plus a separate community set — into Claude Code, Cursor, Codex, VS Code, or Antigravity.
@@ -84,6 +84,7 @@ New catalog entries appear below; notable non-entry changes (formatting, labels,
 
 | Date | Entry | Category |
 | --- | --- | --- |
+| 2026-08-05 | [outagedeck/mcp](https://github.com/outagedeck/mcp) | SRE / third-party dependency outage triage |
 | 2026-07-25 | [opentofu/opentofu-mcp-server](https://github.com/opentofu/opentofu-mcp-server) | IaC / OpenTofu Registry MCP |
 | 2026-07-23 | [containers/kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) | Community / Kubernetes and OpenShift |
 | 2026-07-23 | [cisco-ai-defense/mcp-scanner](https://github.com/cisco-ai-defense/mcp-scanner) | Security / MCP server scanning |
@@ -218,6 +219,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines 
 | [newrelic/mcp-server](https://github.com/newrelic/mcp-server) | prod<br>mcp<br>approval<br>evidence | Official New Relic MCP server for APM, dashboard, and NRQL-based observability context. |
 | [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) | prod<br>mcp<br>approval<br>evidence<br>write | Official Dynatrace open-source MCP server for DQL querying, anomaly/incident/Kubernetes investigation, Davis Copilot AI chat, and deployment automation. |
 | [Elastic Agent Builder MCP server docs](https://www.elastic.co/docs/explore-analyze/ai-features/agent-builder/mcp-server) | prod<br>mcp<br>approval<br>evidence | Official Elastic documentation for exposing Agent Builder tools through MCP with Kibana URL and API-key authentication. |
+| [outagedeck/mcp](https://github.com/outagedeck/mcp) | prod<br>mcp<br>evidence<br>write | Official OutageDeck hosted MCP server for pre-debugging third-party dependency checks, vendor incident timelines, and 7–90 day uptime history across 172 cloud and SaaS providers; public tools are keyless and read-only, while account-authenticated custom-provider and alert tools are write-capable. |
 
 ### Official Agent Skills and Frameworks
 

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1822,3 +1822,27 @@
     - mcp
     - approval
     - write
+
+- name: outagedeck/mcp
+  url: https://github.com/outagedeck/mcp
+  category: official-sre-mcp-servers
+  type: hosted-mcp-server
+  framework: MCP Streamable HTTP
+  primary_language: unknown
+  cloud_provider: multi-cloud
+  use_cases:
+    - third-party-dependency-outage-triage
+    - pre-debugging-stack-health-checks
+    - vendor-incident-timeline-retrieval
+    - cloud-and-saas-uptime-history
+  action_level: write-capable
+  human_approval: unknown
+  evidence_tracing: partial
+  maturity: production-adjacent
+  risk_notes: "The public status, incident, and uptime tools are keyless and read-only, but account-authenticated tools can create, update, and delete custom providers or start email alerts. Keep anonymous use as the default, scope any OutageDeck API key to the intended account, and require client-side confirmation before calling account mutation tools. Calls send named providers and incident identifiers to the hosted OutageDeck service; they do not require cloud credentials. The production implementation is a hosted commercial service rather than OSS; the public GitHub repository contains documentation and registry metadata. Core public checks are free, while some account features depend on an OutageDeck plan."
+  operator_note: "Official OutageDeck hosted MCP server for answering 'is it us or them?' before debugging: one call can check up to 12 dependencies, while other tools return live status, vendor incident timelines, and 7-90 day uptime history for 172 cloud and SaaS providers from their official feeds. The public endpoint is keyless, is active in the official MCP Registry as com.outagedeck/outagedeck-status, and returns source links and observation timestamps."
+  labels:
+    - prod
+    - mcp
+    - evidence
+    - write


### PR DESCRIPTION
## Operator use case

Adds the official OutageDeck hosted MCP server to the SRE catalog. It gives an operator or coding agent a cheap first triage step before investigating a failed deploy or integration: check up to 12 third-party dependencies in one call, then pull official-feed incident timelines and independent 7–90 day uptime history for anything reporting a problem.

## Classification and disclosure

- Type: hosted MCP server, Streamable HTTP
- Official project surface: https://github.com/outagedeck/mcp
- Endpoint: `https://outagedeck.com/api/mcp`
- Registry: `com.outagedeck/outagedeck-status` v1.1.0
- Coverage: 172 cloud and SaaS vendors
- Public tools: keyless and read-only
- Account tools: write-capable; can manage custom providers and start alerts
- No cloud credentials required
- Hosted commercial service; production implementation is not OSS, and the public repository contains documentation and registry metadata
- Core public checks are free; some account features depend on plan

The entry therefore marks the overall server write-capable, calls out the safer anonymous default, leaves human approval as unknown rather than assuming client behavior, and documents the data boundary and account-tool risk.

## Verification

- Live `initialize` and `tools/list` succeeded on 2026-08-05
- Repository is public and reachable
- Official MCP Registry record is active
- `validate_repos_yaml.py`: 80 entries passed
- `sync_readme_counts.py`: 80 entries / 15 sections
- `pytest -q`: 132 passed
- Mock eval scenarios: 7/7 passed
- GitHub audit: 68/80 reachable, 12 non-GitHub entries skipped, 0 archived
- `git diff --check`: passed