### PR TITLE
docs: add operator safety checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ documented here. The format is based on
 
 ### Added
 
+- **Operator safety checklist.** Added a practical preflight runbook for
+  evaluating DevOps agents and MCP servers with read-only-first credentials,
+  no-secret-in-context handling, dry-run/proposal gates, explicit approvals,
+  blast-radius limits, and audit evidence before production-adjacent use.
 - **Container image release advisor.** Added a complete policy-driven reference
   pipeline with SonarCloud code analysis, pre-build Trivy configuration checks,
   exact-image vulnerability and secret scanning, three team-facing reports,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ documented here. The format is based on
 
 - **Operator safety checklist.** Added a practical preflight runbook for
   evaluating DevOps agents and MCP servers with read-only-first credentials,
-  no-secret-in-context handling, dry-run/proposal gates, explicit approvals,
-  blast-radius limits, and audit evidence before production-adjacent use.
+  domain-specific credential boundaries, no-secret-in-context handling,
+  dry-run/proposal gates, explicit approvals, blast-radius limits, and audit
+  evidence before production-adjacent use.
 - **Container image release advisor.** Added a complete policy-driven reference
   pipeline with SonarCloud code analysis, pre-build Trivy configuration checks,
   exact-image vulnerability and secret scanning, three team-facing reports,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Thanks for helping make this a practical operator-grade index instead of a hype 
 - Disclose if the project is commercial-only or if key functionality is not available in OSS form.
 - Do not include tools that require unsafe credential practices.
 - Prefer entries that can be evaluated without real cloud credentials.
+- For write-capable, credentialed, or production-adjacent entries, use the [operator safety checklist](docs/operator-safety-checklist.md) to confirm least-privilege credentials, no-secret-in-context handling, dry-run/proposal behavior, approval gates, blast-radius limits, and audit evidence.
 - PRs should update [data/repos.yaml](data/repos.yaml) and [README.md](README.md) when the public index changes.
 
 ## Entry checklist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thanks for helping make this a practical operator-grade index instead of a hype 
 - Disclose if the project is commercial-only or if key functionality is not available in OSS form.
 - Do not include tools that require unsafe credential practices.
 - Prefer entries that can be evaluated without real cloud credentials.
-- For write-capable, credentialed, or production-adjacent entries, use the [operator safety checklist](docs/operator-safety-checklist.md) to confirm least-privilege credentials, no-secret-in-context handling, dry-run/proposal behavior, approval gates, blast-radius limits, and audit evidence.
+- For write-capable, credentialed, or production-adjacent entries, use the [operator safety checklist](docs/operator-safety-checklist.md) to confirm domain-specific least-privilege credential boundaries, no-secret-in-context handling, dry-run/proposal behavior, approval gates, blast-radius limits, and audit evidence.
 - PRs should update [data/repos.yaml](data/repos.yaml) and [README.md](README.md) when the public index changes.
 
 ## Entry checklist

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ At minimum, record an explicit approval before any write-capable agent mutates i
 
 ## Operator safety checklist
 
-Before wiring any catalog entry into cloud accounts, clusters, CI/CD, identity, secrets, databases, observability, or incident-response systems, run through the [operator safety checklist](docs/operator-safety-checklist.md). It gives teams a concrete preflight for read-only-first evaluation, no-secret-in-context handling, dry-run/proposal evidence, approval gates, blast-radius limits, and audit artifacts.
+Before wiring any catalog entry into cloud accounts, clusters, CI/CD, identity, secrets, databases, observability, or incident-response systems, run through the [operator safety checklist](docs/operator-safety-checklist.md). It gives teams a concrete preflight for read-only-first evaluation, domain-specific credential boundaries, no-secret-in-context handling, dry-run/proposal evidence, approval gates, blast-radius limits, and audit artifacts.
 
 ## Top picks by use case
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ Most agent lists stop at discovery. This one is built for operators:
 - **Installable, not just readable** — [one command](#install-skills-into-your-coding-agent) installs hundreds of skills from cataloged Google, Microsoft, Azure, Azure DevOps, and Harness sources — plus a separate community set — into Claude Code, Cursor, Codex, VS Code, or Antigravity.
 - **Runnable, not just theoretical** — documented [reference-agent examples](#local-reference-agents) cover Terraform plan review, drift detection, and policy-driven container image releases.
 
-**Safety first:** some cataloged tools and agents can change infrastructure. Prefer read-only or proposal mode, require human approval before write actions, and use least-privilege credentials — full guidance in the [safety model](docs/safety-model.md).
+**Safety first:** some cataloged tools and agents can change infrastructure. Prefer read-only or proposal mode, require human approval before write actions, and use least-privilege credentials — full guidance in the [safety model](docs/safety-model.md) and the practical [operator safety checklist](docs/operator-safety-checklist.md).
 
 ## Contents
 
 - [Evaluation labels](#evaluation-labels)
 - [Compliance evidence checklist](#compliance-evidence-checklist)
+- [Operator safety checklist](#operator-safety-checklist)
 - [Top picks by use case](#top-picks-by-use-case)
 - [Install skills into your coding agent](#install-skills-into-your-coding-agent)
 - [Recently added](#recently-added)
@@ -45,6 +46,10 @@ Labels are shorthand for structured fields recorded on every entry in [data/repo
 Production-adjacent agent runs need a reviewable evidence packet, not just a chat transcript. Use the [compliance evidence checklist](docs/compliance-evidence.md) to capture request context, identity and data boundaries, redacted tool calls, approval records, validation output, and follow-ups for MCP servers, skills, incident copilots, Terraform reviewers, and other DevOps agents.
 
 At minimum, record an explicit approval before any write-capable agent mutates infrastructure, source control, CI/CD, identity, secrets, incidents, or production telemetry configuration. If the approval cannot be captured, keep the agent in read-only or proposal mode.
+
+## Operator safety checklist
+
+Before wiring any catalog entry into cloud accounts, clusters, CI/CD, identity, secrets, databases, observability, or incident-response systems, run through the [operator safety checklist](docs/operator-safety-checklist.md). It gives teams a concrete preflight for read-only-first evaluation, no-secret-in-context handling, dry-run/proposal evidence, approval gates, blast-radius limits, and audit artifacts.
 
 ## Top picks by use case
 

--- a/docs/operator-safety-checklist.md
+++ b/docs/operator-safety-checklist.md
@@ -1,0 +1,88 @@
+# Operator safety checklist for DevOps agents
+
+Use this checklist before connecting any MCP server, agent skill, or reference agent from this catalog to real infrastructure. It turns the repo's safety model into a short runbook that works for Terraform, Kubernetes, CI/CD, identity, secrets, observability, and incident-response tools.
+
+## 1. Start read-only
+
+- Create a read-only token, service account, kubeconfig, or database user first.
+- Prefer hosted read-only MCP endpoints or server flags when the vendor provides them.
+- Do not give the agent broad cloud-admin, org-owner, cluster-admin, production database writer, or secrets-admin access for evaluation.
+- Confirm the first demo can run without modifying infrastructure.
+
+Good first actions:
+
+```text
+terraform plan
+kubectl get / kubectl describe
+cloud inventory list/read APIs
+CI run, artifact, and log reads
+observability metric/log/trace queries
+issue, PR, incident, or ticket reads
+```
+
+## 2. Keep secrets out of model context
+
+- Never paste raw tokens, kubeconfigs, private keys, customer data, database dumps, or unredacted logs into chat.
+- Pass credentials through the MCP server, local environment, secret manager, or platform identity layer instead of prompt text.
+- Redact command output before sharing it with the model.
+- Treat screenshots and copied terminal buffers as possible secret carriers.
+
+## 3. Require dry-run or proposal mode before writes
+
+For write-capable entries, require one of these before any mutation:
+
+| Domain | Safer preview |
+| --- | --- |
+| Terraform / OpenTofu | `plan`, drift report, policy check, cost estimate |
+| Kubernetes | server-side dry run, diff, event/log review, scoped namespace test |
+| CI/CD and GitOps | PR-only change, pipeline validation, preview environment |
+| Cloud resources | change set, deployment preview, read-only inventory diff |
+| Identity / secrets | separate request ticket, scoped test object, rollback plan |
+| Incidents / tickets | draft/comment proposal before paging, closing, assigning, or escalating |
+
+If the tool has no dry-run mode, keep it in read-only/proposal mode until a human can review the exact command or API request it would run.
+
+## 4. Define the human approval gate
+
+Before enabling writes, record:
+
+- who can approve;
+- where approval is captured, such as a PR review, protected environment, ticket, incident timeline, or chatops approval;
+- which actions require approval, including deploy, delete, rotate, page, close, merge, or permission changes;
+- which actions remain blocked entirely.
+
+Client-side approval prompts are useful, but server-side controls, RBAC, protected environments, and policy-as-code are stronger because they do not depend on a single chat client behaving correctly.
+
+## 5. Limit blast radius
+
+- Scope cloud roles to one account, project, subscription, region, or resource group for the first run.
+- Scope Kubernetes credentials to one namespace and avoid `cluster-admin`.
+- Use a non-production workspace, preview stack, sandbox repository, or test incident service when possible.
+- Separate read and write credentials so switching to write mode is an explicit operator action.
+- Time-box elevated tokens and rotate or revoke them after evaluation.
+
+## 6. Capture evidence and audit logs
+
+Keep enough evidence for another operator to replay the decision:
+
+- catalog entry and version or commit reviewed;
+- upstream documentation links used for scoring;
+- commands, tool calls, and redacted outputs;
+- plan/diff/report artifacts;
+- approval record and approver;
+- final action result and rollback/follow-up.
+
+For deeper reviews, copy the findings into [`templates/agent-scorecard.md`](../templates/agent-scorecard.md) and attach the scorecard to the PR, ticket, incident, or runbook that authorized the agent.
+
+## 7. Production-adjacent go/no-go
+
+Do not move beyond evaluation until all statements are true:
+
+- the entry's `action_level`, `human_approval`, `evidence_tracing`, `maturity`, `risk_notes`, `operator_note`, and labels match the real tool surface;
+- credentials are least-privilege and not present in model context;
+- dry-run/proposal evidence was reviewed;
+- write actions have an explicit human approval path;
+- audit logs or evidence traces are available after the run;
+- rollback, revoke, or disable steps are known.
+
+If any item is unclear, keep the agent read-only and open a catalog or upstream issue before production use.

--- a/docs/operator-safety-checklist.md
+++ b/docs/operator-safety-checklist.md
@@ -20,6 +20,17 @@ observability metric/log/trace queries
 issue, PR, incident, or ticket reads
 ```
 
+Before evaluating the agent, write down the exact credential boundary instead of relying on a generic "read-only" label:
+
+| Domain | First credential boundary |
+| --- | --- |
+| Cloud / FinOps | one account, project, subscription, billing workspace, or resource group with list/read and cost-viewer permissions |
+| Kubernetes | one namespace-scoped role for get/list/watch/logs/events; no secrets reads unless the workflow is specifically about secrets |
+| Terraform / OpenTofu | plan-only workspace token or repository read token; keep apply tokens separate |
+| CI/CD and GitOps | repository or project read token for workflows, deployments, artifacts, logs, and pull-request creation if proposal mode is needed |
+| Identity / secrets | test tenant, test app, or non-production secret path; block bulk export and production rotation during evaluation |
+| Observability / incidents | telemetry query scope plus incident read/comment scope; page, resolve, suppress, or escalation writes stay disabled until approved |
+
 ## 2. Keep secrets out of model context
 
 - Never paste raw tokens, kubeconfigs, private keys, customer data, database dumps, or unredacted logs into chat.

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -2,6 +2,8 @@
 
 Infrastructure agents need a stricter safety bar than generic chat assistants. The default posture should be read-only observation, proposal-mode recommendations, and human approval before any write action.
 
+For a practical preflight before enabling a cataloged MCP server or agent against real infrastructure, use the [operator safety checklist](operator-safety-checklist.md).
+
 ## Principles
 
 ### Read-only first


### PR DESCRIPTION
## Summary

- add docs/operator-safety-checklist.md as a practical preflight for DevOps agent and MCP server evaluation
- add domain-specific first credential boundaries for cloud/FinOps, Kubernetes, Terraform/OpenTofu, CI/CD, identity/secrets, and observability/incident workflows
- link the checklist from README, docs/safety-model.md, and CONTRIBUTING.md
- document the change in CHANGELOG.md

## Validation

- python3 scripts/validate_repos_yaml.py
- python3 scripts/sync_readme_counts.py --check
- /Users/tuximac/projects/awesome-agentic-devops/.venv/bin/python -m pytest -q
- git diff --check

## Risk

Low. Documentation-only change; no catalog entries, workflow files, credentials, or generated data changed.

Auto-updated by daily maintainer cron on 2026-08-06.
