### PR TITLE
feat: add GitHub audit stale repo warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ documented here. The format is based on
   rejects entries where `action_level: write-capable` and the README-facing
   `write` label drift apart, keeping blast-radius warnings consistent between
   `data/repos.yaml` and generated catalog tables.
+- **Expanded GitHub repository freshness audits.** The audit script now flags
+  GitHub repos with no pushes in the configured freshness window (`--stale-days`,
+  default 365), alongside reachability, archived/private, and language-drift
+  warnings.
 - **Replaced the emoji evaluation labels with text badges.** The six glyphs
   (🟢 🟡 🔵 🛡️ 📊 ⚠️) are now readable tokens — `prod`, `prototype`, `mcp`,
   `approval`, `evidence`, `write` — across the legend, all catalog rows,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,5 @@ pytest -q
 ```
 
 `sync_readme_counts.py` refreshes the entry/category counts in the README intro from `data/repos.yaml`, so you never edit those numbers by hand.
+
+For a deeper freshness check before substantial catalog work, run `python scripts/audit_github_repos.py --stale-days 365`; it writes JSON and Markdown reports under `reports/` and warns on unreachable, archived, private, language-drifted, or stale GitHub repositories.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Most agent lists stop at discovery. This one is built for operators:
 
 - **Official-first, community-inclusive** — 79 entries organized into 15 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
 - **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
-- **Audited by CI** — GitHub repository entries are checked weekly for reachability and archived status; non-GitHub documentation links are outside this automated check and require curator review.
+- **Audited by CI** — GitHub repository entries are checked weekly for reachability, archived status, and stale push activity; non-GitHub documentation links are outside this automated check and require curator review.
 - **Installable, not just readable** — [one command](#install-skills-into-your-coding-agent) installs hundreds of skills from cataloged Google, Microsoft, Azure, Azure DevOps, and Harness sources — plus a separate community set — into Claude Code, Cursor, Codex, VS Code, or Antigravity.
 - **Runnable, not just theoretical** — documented [reference-agent examples](#local-reference-agents) cover Terraform plan review, drift detection, and policy-driven container image releases.
 

--- a/scripts/audit_github_repos.py
+++ b/scripts/audit_github_repos.py
@@ -6,6 +6,7 @@ import json
 import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import urlparse
@@ -77,7 +78,22 @@ def run_command(cmd: list[str]) -> tuple[int, str, str]:
     return completed.returncode, completed.stdout, completed.stderr
 
 
-def _field_warnings(entry: dict[str, Any], metadata: dict[str, Any]) -> list[str]:
+def _parse_github_timestamp(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _field_warnings(
+    entry: dict[str, Any],
+    metadata: dict[str, Any],
+    *,
+    stale_days: int | None = 365,
+    now: datetime | None = None,
+) -> list[str]:
     warnings: list[str] = []
     expected_language = str(entry.get("primary_language", "")).strip()
     actual_language = (metadata.get("primaryLanguage") or {}).get("name") or ""
@@ -93,10 +109,21 @@ def _field_warnings(entry: dict[str, Any], metadata: dict[str, Any]) -> list[str
     if metadata.get("isPrivate"):
         warnings.append("repository is private")
 
+    pushed_at = _parse_github_timestamp(metadata.get("pushedAt") or "")
+    if stale_days and pushed_at:
+        reference_time = now or datetime.now(UTC)
+        if pushed_at < reference_time - timedelta(days=stale_days):
+            warnings.append(f"repository has not been pushed in {stale_days}+ days")
+
     return warnings
 
-
-def audit_repo(entry: dict[str, Any], runner: Runner = run_command) -> AuditResult:
+def audit_repo(
+    entry: dict[str, Any],
+    runner: Runner = run_command,
+    *,
+    stale_days: int | None = 365,
+    now: datetime | None = None,
+) -> AuditResult:
     name = str(entry["name"])
     url = str(entry["url"])
     try:
@@ -146,7 +173,7 @@ def audit_repo(entry: dict[str, Any], runner: Runner = run_command) -> AuditResu
         primary_language=primary_language.get("name") or "",
         description=metadata.get("description") or "",
         stars=metadata.get("stargazerCount"),
-        warnings=_field_warnings(entry, metadata),
+        warnings=_field_warnings(entry, metadata, stale_days=stale_days, now=now),
     )
 
 
@@ -158,10 +185,18 @@ def load_entries(path: Path) -> list[dict[str, Any]]:
     return data
 
 
-def audit_entries(entries: list[dict[str, Any]], workers: int) -> list[AuditResult]:
+def audit_entries(
+    entries: list[dict[str, Any]],
+    workers: int,
+    *,
+    stale_days: int | None = 365,
+) -> list[AuditResult]:
     results: list[AuditResult] = []
     with ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = [executor.submit(audit_repo, entry) for entry in entries]
+        futures = [
+            executor.submit(audit_repo, entry, stale_days=stale_days)
+            for entry in entries
+        ]
         for future in as_completed(futures):
             results.append(future.result())
     return sorted(results, key=lambda result: result.name.lower())
@@ -235,6 +270,12 @@ def main() -> int:
         default=Path("reports/github-repo-audit.md"),
     )
     parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument(
+        "--stale-days",
+        type=int,
+        default=365,
+        help="Warn when GitHub repos have no pushes in this many days; use 0 to disable.",
+    )
     parser.add_argument("--fail-on-unreachable", action="store_true")
     args = parser.parse_args()
 
@@ -246,7 +287,12 @@ def main() -> int:
         parser.error(str(exc))
 
     entries = load_entries(data_path)
-    results = audit_entries(entries, workers=max(1, args.workers))
+    stale_days = args.stale_days if args.stale_days > 0 else None
+    results = audit_entries(
+        entries,
+        workers=max(1, args.workers),
+        stale_days=stale_days,
+    )
     write_report(results, json_path=json_path, markdown_path=markdown_path)
 
     summary = build_summary(results)

--- a/scripts/audit_github_repos.py
+++ b/scripts/audit_github_repos.py
@@ -117,6 +117,7 @@ def _field_warnings(
 
     return warnings
 
+
 def audit_repo(
     entry: dict[str, Any],
     runner: Runner = run_command,

--- a/tests/test_audit_github_repos.py
+++ b/tests/test_audit_github_repos.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -71,6 +72,32 @@ def test_audit_repo_records_unreachable_repo():
 
     assert result.reachable is False
     assert result.error == "Could not resolve to a Repository"
+
+
+def test_audit_repo_warns_when_repository_is_stale():
+    payload = {
+        "nameWithOwner": "vendor/stale-tool",
+        "url": "https://github.com/vendor/stale-tool",
+        "isArchived": False,
+        "isPrivate": False,
+        "defaultBranchRef": {"name": "main"},
+        "pushedAt": "2025-01-01T00:00:00Z",
+        "primaryLanguage": {"name": "Python"},
+        "description": "Stale tool",
+        "stargazerCount": 1,
+    }
+
+    def runner(_cmd):
+        return 0, json.dumps(payload), ""
+
+    result = audit_repo(
+        {"name": "vendor/stale-tool", "url": payload["url"]},
+        runner=runner,
+        stale_days=365,
+        now=datetime(2026, 8, 6, tzinfo=UTC),
+    )
+
+    assert "repository has not been pushed in 365+ days" in result.warnings
 
 
 def test_audit_repo_skips_non_github_urls():


### PR DESCRIPTION
## Summary

- add stale-push warnings to scripts/audit_github_repos.py with configurable --stale-days support
- keep the default weekly GitHub audit focused on reachability, archived/private state, language drift, and repos with no pushes in 365+ days
- document the freshness audit in README, CONTRIBUTING, and CHANGELOG
- add regression coverage for stale repository warnings

## Validation

- python3 scripts/validate_repos_yaml.py
- python3 scripts/sync_readme_counts.py --check
- /Users/tuximac/projects/awesome-agentic-devops/.venv/bin/python -m pytest -q
- git diff --check
- python3 scripts/audit_github_repos.py --data data/repos.yaml --json-output reports/daily-audit-test.json --markdown-output reports/daily-audit-test.md --workers 4 --stale-days 365

## Risk

Low. This changes only catalog audit reporting and docs; no catalog entries, workflow files, credentials, or generated catalog data changed. Temporary audit output was removed before commit.

Auto-generated by daily maintainer cron on 2026-08-06.
