### PR TITLE
feat: add Heroku MCP server to catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated, **official-first** catalog of MCP servers, agent skills, AI agents, f
 
 Most agent lists stop at discovery. This one is built for operators:
 
-- **Official-first, community-inclusive** — 79 entries organized into 15 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
+- **Official-first, community-inclusive** — 80 entries organized into 15 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
 - **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
 - **Audited by CI** — GitHub repository entries are checked weekly for reachability, archived status, and stale push activity; non-GitHub documentation links are outside this automated check and require curator review.
 - **Installable, not just readable** — [one command](#install-skills-into-your-coding-agent) installs hundreds of skills from cataloged Google, Microsoft, Azure, Azure DevOps, and Harness sources — plus a separate community set — into Claude Code, Cursor, Codex, VS Code, or Antigravity.
@@ -89,6 +89,7 @@ New catalog entries appear below; notable non-entry changes (formatting, labels,
 
 | Date | Entry | Category |
 | --- | --- | --- |
+| 2026-08-07 | [heroku/heroku-mcp-server](https://github.com/heroku/heroku-mcp-server) | Cloud / Heroku PaaS operations |
 | 2026-07-25 | [opentofu/opentofu-mcp-server](https://github.com/opentofu/opentofu-mcp-server) | IaC / OpenTofu Registry MCP |
 | 2026-07-23 | [containers/kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) | Community / Kubernetes and OpenShift |
 | 2026-07-23 | [cisco-ai-defense/mcp-scanner](https://github.com/cisco-ai-defense/mcp-scanner) | Security / MCP server scanning |
@@ -141,6 +142,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines 
 | [googleapis/gcloud-mcp](https://github.com/googleapis/gcloud-mcp) | prod<br>mcp<br>approval<br>write | Official Google API repository for gcloud, observability, storage, and backup/disaster-recovery MCP servers. |
 | [GoogleCloudPlatform/cloud-run-mcp](https://github.com/GoogleCloudPlatform/cloud-run-mcp) | prod<br>mcp<br>approval<br>write | Official Google Cloud Platform MCP server for deploying apps to Cloud Run. |
 | [cloudflare/mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare) | prod<br>mcp<br>approval<br>write | Official Cloudflare MCP servers for account, Workers, and edge configuration workflows. |
+| [heroku/heroku-mcp-server](https://github.com/heroku/heroku-mcp-server) | prototype<br>mcp<br>approval<br>write | Official Heroku Platform MCP Server using the Heroku CLI for app lifecycle management, deploys, dyno scaling/restarts, logs, add-ons, pipelines, teams/spaces, and Heroku Postgres operations. |
 | [vercel/vercel-mcp-overview](https://github.com/vercel/vercel-mcp-overview) | prod<br>mcp<br>approval<br>write | Official public overview of Vercel's hosted MCP server for project and deployment context. |
 | [digitalocean-labs/mcp-digitalocean](https://github.com/digitalocean-labs/mcp-digitalocean) | prototype<br>mcp<br>approval<br>write | DigitalOcean Labs MCP integration for self-hosted cloud operations over DigitalOcean droplets, App Platform, databases, and account resources. |
 

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1330,6 +1330,30 @@
     - approval
     - write
 
+- name: heroku/heroku-mcp-server
+  url: https://github.com/heroku/heroku-mcp-server
+  category: official-cloud-mcp-servers
+  type: mcp-server
+  framework: MCP + Heroku CLI
+  primary_language: TypeScript
+  cloud_provider: Heroku
+  use_cases:
+    - heroku-app-management
+    - paas-deployment-and-scaling
+    - postgres-and-add-on-operations
+    - platform-agent-workflows
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: partial
+  maturity: prototype
+  risk_notes: "Early-development official server that uses Heroku CLI auth or HEROKU_API_KEY to read and mutate live Heroku apps, dynos, add-ons, pipelines, and Postgres databases. Prefer `heroku mcp:start` to avoid exposing API keys, scope authorization tokens tightly, and require approval before deploy, scale, restart, add-on, maintenance, pipeline, or SQL actions."
+  operator_note: "Official Heroku Platform MCP Server using the Heroku CLI, with tools for app lifecycle management, deploys, dyno scaling/restarts, logs, add-ons, pipelines, teams/spaces, and Heroku Postgres operations."
+  labels:
+    - prototype
+    - mcp
+    - approval
+    - write
+
 - name: CircleCI-Public/mcp-server-circleci
   url: https://github.com/CircleCI-Public/mcp-server-circleci
   category: official-ci-cd-mcp-servers


### PR DESCRIPTION
## Summary
- Adds the official `heroku/heroku-mcp-server` catalog entry with operator safety scoring.
- Updates the README count, Recently added table, and Official Cloud MCP Servers section.
- Daily maintainer refresh on 2026-08-09 confirmed the branch is current with `origin/main` and the catalog/test validations still pass.

## Verification
- `python3 scripts/validate_repos_yaml.py` - passed: 80 repo entries.
- `python3 scripts/sync_readme_counts.py` - passed: README counts are in sync.
- `python3 scripts/sync_catalog_json.py` - passed: generated catalog sidecar is in sync.
- `python3 -m pytest -q` - base interpreter missing pytest, expected for a bare environment.
- `python3 -m venv .venv && . .venv/bin/activate && python -m pip install -e '.[dev]' && python -m pytest -q` - passed: 133 tests.
- `validate_entries(yaml.safe_load(data))` against latest remote `main` content before API branch creation.

## Source checks
- Official Heroku blog announces the official Heroku MCP Server.
- `heroku/heroku-mcp-server` README documents Heroku CLI authentication, `heroku mcp:start`, and write-capable tools for apps, dynos, add-ons, pipelines, and Postgres.

## Risk notes
- The cataloged Heroku MCP surface is write-capable; operators should use least-privilege auth, prefer CLI-mediated auth where practical, and require explicit approval for deploy, scale, restart, add-on, pipeline, maintenance, and SQL actions.
- GitHub reports `mergeStateStatus: BLOCKED` even though reported checks pass, likely due required review or branch-protection policy.
