### PR TITLE
Add Nexus Shell Agent Bridge for visible SSH operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated, **official-first** catalog of MCP servers, agent skills, AI agents, f
 
 Most agent lists stop at discovery. This one is built for operators:
 
-- **Official-first, community-inclusive** — 79 entries organized into 15 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
+- **Official-first, community-inclusive** — 80 entries organized into 15 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
 - **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
 - **Audited by CI** — GitHub repository entries are checked weekly for reachability, archived status, and stale push activity; non-GitHub documentation links are outside this automated check and require curator review.
 - **Installable, not just readable** — [one command](#install-skills-into-your-coding-agent) installs hundreds of skills from cataloged Google, Microsoft, Azure, Azure DevOps, and Harness sources — plus a separate community set — into Claude Code, Cursor, Codex, VS Code, or Antigravity.
@@ -89,6 +89,7 @@ New catalog entries appear below; notable non-entry changes (formatting, labels,
 
 | Date | Entry | Category |
 | --- | --- | --- |
+| 2026-08-10 | [Nexus Shell Agent Bridge](https://github.com/viewer12/Nexus-Shell-Releases) | DevOps / local SSH and SFTP operations |
 | 2026-07-25 | [opentofu/opentofu-mcp-server](https://github.com/opentofu/opentofu-mcp-server) | IaC / OpenTofu Registry MCP |
 | 2026-07-23 | [containers/kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) | Community / Kubernetes and OpenShift |
 | 2026-07-23 | [cisco-ai-defense/mcp-scanner](https://github.com/cisco-ai-defense/mcp-scanner) | Security / MCP server scanning |
@@ -156,6 +157,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines 
 | [docker/mcp-registry](https://github.com/docker/mcp-registry) | prod<br>mcp<br>approval<br>evidence | Official Docker MCP registry and catalog source for verified containerized MCP servers. |
 | [docker/hub-mcp](https://github.com/docker/hub-mcp) | prototype<br>mcp<br>approval<br>write | Official Docker Hub MCP server for AI-assisted image discovery, image recommendations, and Docker Hub repository workflows. |
 | [kubernetes-sigs/mcp-lifecycle-operator](https://github.com/kubernetes-sigs/mcp-lifecycle-operator) | prototype<br>mcp<br>approval<br>write | Official Kubernetes SIG operator for declaratively deploying and rolling out MCP servers, not a general kubectl MCP server. |
+| [Nexus Shell Agent Bridge](https://github.com/viewer12/Nexus-Shell-Releases) | prototype<br>mcp<br>approval<br>evidence<br>write | Official local MCP server in the proprietary Nexus Shell macOS app for visible SSH terminal operations, SFTP, SSH keys, and read-only monitoring, with per-agent consent and a redacted local audit trail. |
 
 ### Official Security and Code-Quality MCP Servers
 

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -433,6 +433,31 @@
     - approval
     - write
 
+- name: Nexus Shell Agent Bridge
+  url: https://github.com/viewer12/Nexus-Shell-Releases
+  category: official-devops-mcp-servers
+  type: mcp-server
+  framework: MCP + native macOS SSH/SFTP client
+  primary_language: Swift
+  cloud_provider: multi-cloud
+  use_cases:
+    - visible-ssh-terminal-operations
+    - sftp-file-transfer
+    - ssh-key-management
+    - read-only-server-and-network-monitoring
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: "yes"
+  maturity: prototype
+  risk_notes: "After an agent is approved, it can run arbitrary shell commands and create, update, or delete connections and remote files using the app's saved credentials. Consent is per agent (once or always), not per command, and there is no built-in dry-run mode. Start on non-production hosts with least-privilege remote accounts, review visible terminal tabs, revoke access after use, and assume command output may expose secrets to the model."
+  operator_note: "Official local MCP server built into the proprietary Nexus Shell macOS app, exposing 26 tools for SSH terminals, SFTP, SSH keys, session metadata, and read-only monitoring. It uses a same-user Unix socket, never returns stored passwords or private keys, shows agent-opened terminals in the app, and writes a redacted local JSONL audit trail. Agent Bridge is available only in the direct-download and Homebrew builds."
+  labels:
+    - prototype
+    - mcp
+    - approval
+    - evidence
+    - write
+
 - name: SonarSource/sonarqube-mcp-server
   url: https://github.com/SonarSource/sonarqube-mcp-server
   category: official-security-mcp-servers


### PR DESCRIPTION
## Summary

Adds the official Nexus Shell Agent Bridge to the Official DevOps MCP Servers section. It is a local MCP server in a native macOS SSH client, giving operators 26 tools for visible SSH terminal work, SFTP, SSH key operations, session metadata, and read-only server/network monitoring.

## Classification and disclosure

- Official product surface: https://github.com/viewer12/Nexus-Shell-Releases
- Security and operator documentation: https://nexusshell.app/agent-bridge
- Type: local stdio MCP server backed by a same-user Unix domain socket
- Action level: write-capable
- Human approval: per-agent consent, either once or persistent; not per-command approval
- Evidence: one redacted local JSONL record per tool call and connection event
- Maturity: prototype because Agent Bridge is still described as experimental
- Cloud scope: multi-cloud through saved SSH connections
- Product model: proprietary freemium macOS app; the public repository contains signed releases, release notes, issue tracking, and product documentation, not application source
- Distribution boundary: Agent Bridge is available only in the direct-download and Homebrew builds, not the Mac App Store/TestFlight build
- Developer disclosure: I am submitting this on behalf of Nexus Shell. Codex assisted with catalog formatting and validation.

## Operator safety

Approved agents can run arbitrary remote commands and create, update, or delete connections and files using the credentials already held by Nexus Shell. The bridge does not provide a built-in dry-run mode or per-command confirmation. Operators should start with non-production hosts, use dedicated least-privilege remote accounts, inspect the visible terminal tabs, treat returned command output as potentially sensitive, and revoke the agent when finished. Stored passwords and private keys are never returned to the MCP client.

## Entry checklist

- [x] The repo URL is public and reachable.
- [x] The entry has a specific category.
- [x] The `risk_notes` field explains what could go wrong.
- [x] The `operator_note` field explains why an infrastructure operator should care.
- [x] Labels match the observed behavior, not marketing claims.
- [x] `data/repos.yaml` and `README.md` are both updated.

## Safety checklist

- [x] No secrets, tokens, kubeconfigs, customer data, or private logs are included.
- [x] Write capability, approval limits, lack of dry-run, audit evidence, and revoke/rollback expectations are documented.
- [x] Credential guidance uses least-privilege remote accounts and recommends separate non-production connections for evaluation.
- [x] The proprietary application and local-only service boundary are disclosed.

## Validation

- `python scripts/validate_repos_yaml.py`: 80 entries passed
- `python scripts/sync_readme_counts.py --check`: 80 entries / 15 sections
- `python -m pytest -q`: 133 passed
- `python scripts/run_mock_eval_scenarios.py`: 7/7 passed
- `python scripts/audit_github_repos.py --workers 12 --fail-on-unreachable`: 68/80 GitHub repositories reachable, 12 non-GitHub entries skipped, 0 archived
- `git diff --check`: passed