### PR TITLE
test: guard catalog score label consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,9 @@ documented here. The format is based on
   `write` label drift apart, keeping blast-radius warnings consistent between
   `data/repos.yaml` and generated catalog tables.
 - **Hardened maturity label validation.** The catalog validator now rejects rows
-  that mix `prod` and `prototype` labels, forcing contributors to choose one
-  maturity signal instead of publishing conflicting readiness shorthand.
+  that mix `prod` and `prototype` labels, and rejects `maturity: prototype` rows
+  that omit `prototype` or use `prod`, forcing contributors to keep beta and
+  experimental entries aligned with README readiness shorthand.
 - **Expanded GitHub repository freshness audits.** The audit script now flags
   GitHub repos with no pushes in the configured freshness window (`--stale-days`,
   default 365), alongside reachability, archived/private, and language-drift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ documented here. The format is based on
   values, and `labels` / `use_cases` must contain at least one non-empty string
   item so incomplete catalog rows fail locally before reaching README generation
   or CI.
+- **Hardened score-to-label consistency.** The catalog validator now keeps
+  README-facing `approval` and `evidence` labels synchronized with the structured
+  `human_approval` and `evidence_tracing` fields, preventing safety and audit
+  signals from drifting between `data/repos.yaml` and the public tables.
 - **Hardened catalog URL validation.** Catalog entries now require absolute
   `https://` URLs, blocking accidental relative links, bare hostnames, and
   insecure `http://` sources from entering the operator index.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ Thanks for helping make this a practical operator-grade index instead of a hype 
 - The `operator_note` field explains why an infrastructure operator should care.
 - Labels match the observed behavior, not marketing claims.
 - `labels` uses only the current evaluation tokens: `prod`, `prototype`, `mcp`, `approval`, `evidence`, and `write`.
+- Keep README-facing labels synchronized with structured scores: `human_approval: true` requires `approval`; `evidence_tracing: yes` requires `evidence`; `evidence` is allowed only for `yes` or `partial` evidence tracing; and `write` is allowed only with `action_level: write-capable`.
 - Do not combine `prod` and `prototype` on the same entry; choose the stricter maturity signal that matches the evidence.
 
 ## Local validation

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines 
 | --- | --- | --- |
 | [hashicorp/terraform-mcp-server](https://github.com/hashicorp/terraform-mcp-server) | prod<br>mcp<br>approval<br>evidence<br>write | Official HashiCorp Terraform MCP server with registry, HCP Terraform, Terraform Enterprise, and OTel support. |
 | [Pulumi MCP Server](https://www.pulumi.com/docs/ai/mcp-server/) | prod<br>mcp<br>approval<br>write | Official Pulumi hosted MCP server for Pulumi Cloud resources, registry lookup, policies, and Pulumi Neo workflows. |
-| [hashicorp/vault-mcp-server](https://github.com/hashicorp/vault-mcp-server) | prod<br>mcp<br>approval<br>write | Official HashiCorp Vault MCP server (beta) for secrets and mount management alongside Terraform-driven IaC workflows. |
+| [hashicorp/vault-mcp-server](https://github.com/hashicorp/vault-mcp-server) | prototype<br>mcp<br>approval<br>write | Official HashiCorp Vault MCP server for secrets and mount management, complementing the Terraform MCP server for IaC workflows. |
 | [opentofu/opentofu-mcp-server](https://github.com/opentofu/opentofu-mcp-server) | prototype<br>mcp<br>approval | Official OpenTofu MCP server for searching the OpenTofu Registry, retrieving provider/module details, resource and data-source docs, and configuration examples via hosted or local MCP deployment. |
 
 ### Official SRE MCP Servers

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1509,7 +1509,7 @@
   risk_notes: "Beta; tools can touch live secrets engines and mounts, so run locally only, avoid exposing it to other network users, and require approval before write operations."
   operator_note: "Official HashiCorp Vault MCP server for secrets and mount management, complementing the Terraform MCP server for IaC workflows."
   labels:
-    - prod
+    - prototype
     - mcp
     - approval
     - write

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -50,6 +50,6 @@ Do not paste secrets, cloud credentials, kubeconfigs, private keys, tokens, or s
 
 - Every listed project must have an `action_level`.
 - Write-capable entries must carry the `write` label unless the write surface is clearly isolated.
-- Approval-aware entries should carry `approval` only when a meaningful approval or safety mechanism is documented or strongly evident.
-- Evidence-aware entries should carry `evidence` only when there is a trace, eval, audit, cited evidence, or equivalent mechanism.
+- Entries with `human_approval: true` must carry the `approval` label, and `approval` must not be used when the structured field is `false` or `unknown`.
+- Entries with `evidence_tracing: yes` must carry the `evidence` label. The `evidence` label may also be used for partial evidence, but must not be used when tracing is `none` or `unknown`.
 - Deep reviews should use the [agent scorecard template](../templates/agent-scorecard.md) to capture credential boundaries, no-secret-in-context controls, dry-run commands, approval evidence, audit artifacts, and an explicit production-readiness decision before recommending production-adjacent use.

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -14,7 +14,7 @@ Most agent lists stop at discovery. Infrastructure teams need more: whether a to
 
 ## How fields map to README labels
 
-The text labels in the README catalog are shorthand for these fields: `write` maps to `action_level: write-capable`, `approval` to `human_approval: true`, `evidence` to tracing or eval evidence, and `prod`/`prototype` to `maturity`. An `approval` label may represent a server-enforced gate, a client permission prompt, or another documented safety mechanism; consult the entry and upstream documentation to determine enforcement strength.
+The text labels in the README catalog are shorthand for these fields: `write` maps to `action_level: write-capable`, `approval` to `human_approval: true`, `evidence` to tracing or eval evidence, and `prod`/`prototype` to `maturity`. The validator enforces the highest-risk mappings: write-capable rows must carry `write`, human-approval rows must carry `approval`, `evidence_tracing: yes` rows must carry `evidence`, and `evidence` cannot be paired with `evidence_tracing: none` or `unknown`. An `approval` label may represent a server-enforced gate, a client permission prompt, or another documented safety mechanism; consult the entry and upstream documentation to determine enforcement strength.
 
 ## Example: reading one entry
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -14,7 +14,7 @@ Most agent lists stop at discovery. Infrastructure teams need more: whether a to
 
 ## How fields map to README labels
 
-The text labels in the README catalog are shorthand for these fields: `write` maps to `action_level: write-capable`, `approval` to `human_approval: true`, `evidence` to tracing or eval evidence, and `prod`/`prototype` to `maturity`. The validator enforces the highest-risk mappings: write-capable rows must carry `write`, human-approval rows must carry `approval`, `evidence_tracing: yes` rows must carry `evidence`, and `evidence` cannot be paired with `evidence_tracing: none` or `unknown`. An `approval` label may represent a server-enforced gate, a client permission prompt, or another documented safety mechanism; consult the entry and upstream documentation to determine enforcement strength.
+The text labels in the README catalog are shorthand for these fields: `write` maps to `action_level: write-capable`, `approval` to `human_approval: true`, `evidence` to tracing or eval evidence, and `prod`/`prototype` to `maturity`. The validator enforces the highest-risk mappings: write-capable rows must carry `write`, human-approval rows must carry `approval`, `evidence_tracing: yes` rows must carry `evidence`, `evidence` cannot be paired with `evidence_tracing: none` or `unknown`, and `maturity: prototype` rows must use `prototype` rather than `prod`. An `approval` label may represent a server-enforced gate, a client permission prompt, or another documented safety mechanism; consult the entry and upstream documentation to determine enforcement strength.
 
 ## Example: reading one entry
 

--- a/scripts/validate_repos_yaml.py
+++ b/scripts/validate_repos_yaml.py
@@ -223,6 +223,8 @@ def _validate_score_label_consistency(entry: dict[str, Any], index: int) -> None
     labels = set(entry["labels"])
     has_approval_label = "approval" in labels
     has_evidence_label = "evidence" in labels
+    has_prod_label = "prod" in labels
+    has_prototype_label = "prototype" in labels
 
     if entry["human_approval"] is True and not has_approval_label:
         raise ValidationError(f"{name}: human_approval true requires approval label")
@@ -234,6 +236,14 @@ def _validate_score_label_consistency(entry: dict[str, Any], index: int) -> None
         raise ValidationError(
             f"{name}: evidence label requires evidence_tracing yes or partial"
         )
+    if entry["maturity"] == "production-adjacent" and has_prototype_label:
+        raise ValidationError(
+            f"{name}: production-adjacent maturity cannot use prototype label"
+        )
+    if entry["maturity"] == "prototype" and has_prod_label:
+        raise ValidationError(f"{name}: prototype maturity cannot use prod label")
+    if entry["maturity"] == "prototype" and not has_prototype_label:
+        raise ValidationError(f"{name}: prototype maturity requires prototype label")
 
 
 def validate_entries(entries: Any) -> list[dict[str, Any]]:

--- a/scripts/validate_repos_yaml.py
+++ b/scripts/validate_repos_yaml.py
@@ -218,6 +218,24 @@ def _validate_write_label_consistency(entry: dict[str, Any], index: int) -> None
         raise ValidationError(f"{name}: write label requires action_level write-capable")
 
 
+def _validate_score_label_consistency(entry: dict[str, Any], index: int) -> None:
+    name = _entry_name(entry, index)
+    labels = set(entry["labels"])
+    has_approval_label = "approval" in labels
+    has_evidence_label = "evidence" in labels
+
+    if entry["human_approval"] is True and not has_approval_label:
+        raise ValidationError(f"{name}: human_approval true requires approval label")
+    if has_approval_label and entry["human_approval"] is not True:
+        raise ValidationError(f"{name}: approval label requires human_approval true")
+    if entry["evidence_tracing"] == "yes" and not has_evidence_label:
+        raise ValidationError(f"{name}: evidence_tracing yes requires evidence label")
+    if has_evidence_label and entry["evidence_tracing"] in {"none", "unknown"}:
+        raise ValidationError(
+            f"{name}: evidence label requires evidence_tracing yes or partial"
+        )
+
+
 def validate_entries(entries: Any) -> list[dict[str, Any]]:
     if not isinstance(entries, list):
         raise ValidationError("data/repos.yaml must contain a list of repo entries")
@@ -227,6 +245,7 @@ def validate_entries(entries: Any) -> list[dict[str, Any]]:
             raise ValidationError(f"entry #{index + 1} must be a mapping")
         _validate_entry(entry, index)
         _validate_write_label_consistency(entry, index)
+        _validate_score_label_consistency(entry, index)
 
     _validate_unique_field(entries, "name")
     _validate_unique_field(entries, "url")

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -33,7 +33,7 @@ def valid_entry(**overrides):
         "maturity": "prototype",
         "risk_notes": "Requires review before use.",
         "operator_note": "Useful reference pattern.",
-        "labels": ["prototype"],
+        "labels": ["prototype", "approval"],
     }
     entry.update(overrides)
     return entry
@@ -77,7 +77,7 @@ def test_seed_types_match_validator_allowlist():
 
 @pytest.mark.parametrize("action_level", sorted(ALLOWED_ACTION_LEVELS))
 def test_accepts_allowed_action_levels(action_level):
-    labels = ["prototype", "write"] if action_level == "write-capable" else ["prototype"]
+    labels = ["prototype", "approval", "write"] if action_level == "write-capable" else ["prototype", "approval"]
     validate_entries([valid_entry(action_level=action_level, labels=labels)])
 
 
@@ -99,7 +99,18 @@ def test_accepts_allowed_maturity_values(maturity):
 @pytest.mark.parametrize("label", sorted(ALLOWED_LABELS))
 def test_accepts_allowed_labels(label):
     action_level = "write-capable" if label == "write" else "proposal"
-    validate_entries([valid_entry(action_level=action_level, labels=[label])])
+    labels = ["prod" if label == "prod" else "prototype", "approval"]
+    if label not in labels:
+        labels.append(label)
+    validate_entries(
+        [
+            valid_entry(
+                action_level=action_level,
+                evidence_tracing="partial",
+                labels=labels,
+            )
+        ]
+    )
 
 
 def test_rejects_missing_required_field():
@@ -199,6 +210,50 @@ def test_write_label_requires_write_capable_action_level():
     entries = [valid_entry(action_level="proposal", labels=["prototype", "write"])]
 
     with pytest.raises(ValidationError, match="requires action_level write-capable"):
+        validate_entries(entries)
+
+
+def test_human_approval_true_requires_approval_label():
+    entries = [valid_entry(human_approval=True, labels=["prototype"])]
+
+    with pytest.raises(ValidationError, match="requires approval label"):
+        validate_entries(entries)
+
+
+def test_approval_label_requires_human_approval_true():
+    entries = [
+        valid_entry(
+            human_approval="unknown",
+            labels=["prototype", "approval"],
+        )
+    ]
+
+    with pytest.raises(ValidationError, match="requires human_approval true"):
+        validate_entries(entries)
+
+
+def test_evidence_tracing_yes_requires_evidence_label():
+    entries = [
+        valid_entry(
+            evidence_tracing="yes",
+            labels=["prototype", "approval"],
+        )
+    ]
+
+    with pytest.raises(ValidationError, match="requires evidence label"):
+        validate_entries(entries)
+
+
+@pytest.mark.parametrize("evidence_tracing", ["none", "unknown"])
+def test_evidence_label_requires_positive_evidence_tracing(evidence_tracing):
+    entries = [
+        valid_entry(
+            evidence_tracing=evidence_tracing,
+            labels=["prototype", "approval", "evidence"],
+        )
+    ]
+
+    with pytest.raises(ValidationError, match="requires evidence_tracing yes or partial"):
         validate_entries(entries)
 
 

--- a/tests/test_repos_yaml.py
+++ b/tests/test_repos_yaml.py
@@ -93,12 +93,18 @@ def test_accepts_allowed_types(entry_type):
 
 @pytest.mark.parametrize("maturity", sorted(ALLOWED_MATURITY))
 def test_accepts_allowed_maturity_values(maturity):
-    validate_entries([valid_entry(maturity=maturity)])
+    labels = (
+        ["prod", "approval"]
+        if maturity == "production-adjacent"
+        else ["prototype", "approval"]
+    )
+    validate_entries([valid_entry(maturity=maturity, labels=labels)])
 
 
 @pytest.mark.parametrize("label", sorted(ALLOWED_LABELS))
 def test_accepts_allowed_labels(label):
     action_level = "write-capable" if label == "write" else "proposal"
+    maturity = "production-adjacent" if label == "prod" else "prototype"
     labels = ["prod" if label == "prod" else "prototype", "approval"]
     if label not in labels:
         labels.append(label)
@@ -107,6 +113,7 @@ def test_accepts_allowed_labels(label):
             valid_entry(
                 action_level=action_level,
                 evidence_tracing="partial",
+                maturity=maturity,
                 labels=labels,
             )
         ]
@@ -254,6 +261,37 @@ def test_evidence_label_requires_positive_evidence_tracing(evidence_tracing):
     ]
 
     with pytest.raises(ValidationError, match="requires evidence_tracing yes or partial"):
+        validate_entries(entries)
+
+
+def test_production_adjacent_maturity_rejects_prototype_label():
+    entries = [
+        valid_entry(
+            maturity="production-adjacent",
+            labels=["prototype", "approval"],
+        )
+    ]
+
+    with pytest.raises(ValidationError, match="cannot use prototype label"):
+        validate_entries(entries)
+
+
+def test_prototype_maturity_requires_prototype_label():
+    entries = [valid_entry(maturity="prototype", labels=["approval"])]
+
+    with pytest.raises(ValidationError, match="requires prototype label"):
+        validate_entries(entries)
+
+
+def test_prototype_maturity_rejects_prod_label():
+    entries = [
+        valid_entry(
+            maturity="prototype",
+            labels=["prod", "approval"],
+        )
+    ]
+
+    with pytest.raises(ValidationError, match="cannot use prod label"):
         validate_entries(entries)
 
 


### PR DESCRIPTION
## Summary

- Harden catalog validation so README-facing `approval` labels stay synchronized with `human_approval: true`.
- Harden evidence label consistency so `evidence_tracing: yes` requires `evidence`, and `evidence` cannot be used with `none` or `unknown` tracing.
- Extend maturity label guards so `maturity: prototype` entries cannot accidentally publish `prod` shorthand and must retain `prototype` shorthand.
- Correct the HashiCorp Vault MCP catalog row from `prod` to `prototype`, matching its existing `maturity: prototype` beta risk posture.
- Document the score-to-label invariants in scoring, safety, contribution guidance, and the changelog.

## Validation

- `gh auth status` - authenticated as DevOpsAIguru123 with repo scope.
- `gh repo view DevOpsAIguru123/awesome-agentic-devops --json name,owner,defaultBranchRef,url` - confirmed repository identity and main default branch.
- `git switch main && git fetch origin --prune && git pull --ff-only` - local main is current.
- `gh pr list -R DevOpsAIguru123/awesome-agentic-devops --state open --json number,title,url,headRefName,author,body` - found existing daily PR #97, so this run did not create a duplicate bot PR.
- `git switch agentic-devops-daily-20260810-score-label-guards && git merge --ff-only origin/agentic-devops-daily-20260810-score-label-guards && git merge --ff-only origin/main` - PR branch is current with origin/main.
- `python3 scripts/validate_repos_yaml.py` - passed, 80 entries.
- `python3 scripts/sync_readme_counts.py --check` - README counts are in sync: 80 entries organized into 15 catalog sections.
- `/Users/tuximac/projects/awesome-agentic-devops/.venv/bin/python -m pytest -q` - passed, 149 tests.
- `git diff --check` - passed with no whitespace errors.
- `gh pr checks 97 -R DevOpsAIguru123/awesome-agentic-devops` - Validate and SonarCloud Code Analysis are passing.

## Maintainer refresh - 2026-08-11

Daily cron revalidated the existing score-label-guard PR instead of opening a duplicate daily PR. No additional code changes were needed because the branch is already current and checks are green.

## Risk

- Validator and label-alignment tightening only; no new catalog entries or infrastructure changes.
- The HashiCorp Vault MCP row remains write-capable with approval/write warnings; only the readiness shorthand changed from prod to prototype to match existing beta/prototype scoring.
- PR merge state is still blocked by normal repository review/branch-protection requirements, not by failing checks.

Auto-generated by daily maintainer cron for 2026-08-11.
