### PR TITLE
Add vostride/agent-qa

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated, **official-first** catalog of MCP servers, agent skills, AI agents, f
 
 Most agent lists stop at discovery. This one is built for operators:
 
-- **Official-first, community-inclusive** — 80 entries organized into 15 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
+- **Official-first, community-inclusive** — 81 entries organized into 15 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
 - **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
 - **Audited by CI** — GitHub repository entries are checked weekly for reachability, archived status, and stale push activity; non-GitHub documentation links are outside this automated check and require curator review.
 - **Installable, not just readable** — [one command](#install-skills-into-your-coding-agent) installs hundreds of skills from cataloged Google, Microsoft, Azure, Azure DevOps, and Harness sources — plus a separate community set — into Claude Code, Cursor, Codex, VS Code, or Antigravity.
@@ -89,6 +89,7 @@ New catalog entries appear below; notable non-entry changes (formatting, labels,
 
 | Date | Entry | Category |
 | --- | --- | --- |
+| 2026-08-16 | [vostride/agent-qa](https://github.com/vostride/agent-qa) | Community / browser and mobile QA |
 | 2026-08-07 | [heroku/heroku-mcp-server](https://github.com/heroku/heroku-mcp-server) | Cloud / Heroku PaaS operations |
 | 2026-07-25 | [opentofu/opentofu-mcp-server](https://github.com/opentofu/opentofu-mcp-server) | IaC / OpenTofu Registry MCP |
 | 2026-07-23 | [containers/kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) | Community / Kubernetes and OpenShift |
@@ -285,6 +286,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines 
 | [Agents365-ai/drawio-skill](https://github.com/Agents365-ai/drawio-skill) | prototype<br>approval | Community draw.io skill for natural-language diagram generation, visual self-checking, and exports. |
 | [containers/kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) | prod<br>mcp<br>approval<br>evidence<br>write | Community-maintained Containers org MCP server for Kubernetes and OpenShift with direct Kubernetes API access, multi-cluster support, read-only mode, and a read-only production setup guide. |
 | [skyhook-io/radar](https://github.com/skyhook-io/radar) | prod<br>mcp<br>approval<br>evidence<br>write | Community open-source Kubernetes UI with a built-in MCP server: read-only cluster/topology/event queries plus RBAC-scoped write and GitOps/Helm tools for AI-assisted operations. |
+| [vostride/agent-qa](https://github.com/vostride/agent-qa) | prototype<br>mcp<br>evidence<br>write | Community QA toolkit with a dashboard, CLI, MCP server, and Agent Skills for natural-language web/mobile regression tests, persistent execution memory, self-healing, and reviewable artifacts. |
 
 ## How to contribute
 

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1846,3 +1846,27 @@
     - mcp
     - approval
     - write
+
+- name: vostride/agent-qa
+  url: https://github.com/vostride/agent-qa
+  category: community-mcp-servers
+  type: agent-toolkit
+  framework: MCP + Playwright + Appium + Agent Skills
+  primary_language: TypeScript
+  cloud_provider: multi-cloud
+  use_cases:
+    - web-and-mobile-regression-testing
+    - ci-quality-gates
+    - test-failure-triage
+    - agent-driven-qa
+  action_level: write-capable
+  human_approval: unknown
+  evidence_tracing: "yes"
+  maturity: prototype
+  risk_notes: "Runs browser and mobile actions that can click, type, submit forms, invoke hooks, and mutate authenticated test environments; use disposable accounts and test tenants, review scenarios and hooks, scope credentials, and require approval before destructive or production-adjacent steps."
+  operator_note: "Community QA toolkit with a dashboard, CLI, MCP server, and Agent Skills for natural-language web/mobile regression tests; persistent execution memory and self-healing reuse prior observations and produce reviewable run artifacts."
+  labels:
+    - prototype
+    - mcp
+    - evidence
+    - write


### PR DESCRIPTION
## Summary

Adds `vostride/agent-qa` as a community MCP/agent toolkit for natural-language web and mobile regression testing, CI quality gates, and test-failure triage.

The structured entry conservatively classifies its browser/mobile execution as write-capable, records approval behavior as unknown, documents operator risks, and highlights its reviewable run evidence. The README count, recent-additions table, catalog row, and YAML source are updated together.

## Entry checklist

- [x] The repo URL is public and reachable.
- [x] The entry has a specific category.
- [x] The `risk_notes` field explains what could go wrong.
- [x] The `operator_note` field explains why an infrastructure operator should care.
- [x] Labels match the observed behavior, not marketing claims.
- [x] `data/repos.yaml` and `README.md` are both updated.

## Safety checklist

- [x] No secrets, tokens, kubeconfigs, customer data, private logs, or generated artifacts are included.
- [ ] Write-capable tools document approval gates, dry-run or preview behavior, audit/evidence output, and rollback expectations.
  > The entry deliberately uses `human_approval: unknown`; its risk note tells operators to require approval and use disposable accounts/test tenants. The project produces reviewable run artifacts, but this PR does not claim built-in dry-run or rollback guarantees.
- [ ] Credential guidance separates read-only credentials from write-capable credentials.
  > Browser/mobile test accounts are inherently write-capable. The risk note recommends scoped credentials and disposable test tenants rather than asserting a read-only credential mode.
- [x] External dependencies are disclosed here: agent-qa can use OpenAI- or Anthropic-compatible endpoints, Gemini, or local models; hosted-provider telemetry and data handling depend on the operator's chosen provider.

## Validation

```text
python scripts/validate_repos_yaml.py              # passed: 81 entries
python scripts/sync_catalog_json.py --check        # passed: 8 skill sources
python scripts/sync_readme_counts.py --check       # passed: 81 entries / 15 sections
python -m pytest -q                                # passed: 149 tests
python scripts/run_mock_eval_scenarios.py          # passed: 7/7 scenarios
```

The corpus-wide network audit was not run locally; the newly added repository, documentation, and license URLs were checked directly and return HTTP 200. `git diff --check` also passes.

Project disclosure: this submission is for agent-qa itself. The current license is FSL-1.1-ALv2 and converts to Apache-2.0 after two years.
