### PR TITLE
Add dbhq-uk/heliograph-skill to community agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated, **official-first** catalog of MCP servers, agent skills, AI agents, f
 
 Most agent lists stop at discovery. This one is built for operators:
 
-- **Official-first, community-inclusive** — 80 entries organized into 15 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
+- **Official-first, community-inclusive** — 81 entries organized into 15 catalog sections; official vendor and project resources are prioritized, while community-driven entries are separated in a dedicated [community section](#community-discovery-and-skills).
 - **Scored, not just listed** — every entry records action capability, human-approval controls, tracing evidence, maturity, and operational risk ([how entries are scored](docs/scoring.md)).
 - **Audited by CI** — GitHub repository entries are checked weekly for reachability, archived status, and stale push activity; non-GitHub documentation links are outside this automated check and require curator review.
 - **Installable, not just readable** — [one command](#install-skills-into-your-coding-agent) installs hundreds of skills from cataloged Google, Microsoft, Azure, Azure DevOps, and Harness sources — plus a separate community set — into Claude Code, Cursor, Codex, VS Code, or Antigravity.
@@ -89,6 +89,7 @@ New catalog entries appear below; notable non-entry changes (formatting, labels,
 
 | Date | Entry | Category |
 | --- | --- | --- |
+| 2026-08-20 | [dbhq-uk/heliograph-skill](https://github.com/dbhq-uk/heliograph-skill) | Community / operator-mediated remote diagnostics |
 | 2026-08-07 | [heroku/heroku-mcp-server](https://github.com/heroku/heroku-mcp-server) | Cloud / Heroku PaaS operations |
 | 2026-07-25 | [opentofu/opentofu-mcp-server](https://github.com/opentofu/opentofu-mcp-server) | IaC / OpenTofu Registry MCP |
 | 2026-07-23 | [containers/kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) | Community / Kubernetes and OpenShift |
@@ -285,6 +286,7 @@ The source of truth is [data/repos.yaml](data/repos.yaml). The catalog combines 
 | [Agents365-ai/drawio-skill](https://github.com/Agents365-ai/drawio-skill) | prototype<br>approval | Community draw.io skill for natural-language diagram generation, visual self-checking, and exports. |
 | [containers/kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) | prod<br>mcp<br>approval<br>evidence<br>write | Community-maintained Containers org MCP server for Kubernetes and OpenShift with direct Kubernetes API access, multi-cluster support, read-only mode, and a read-only production setup guide. |
 | [skyhook-io/radar](https://github.com/skyhook-io/radar) | prod<br>mcp<br>approval<br>evidence<br>write | Community open-source Kubernetes UI with a built-in MCP server: read-only cluster/topology/event queries plus RBAC-scoped write and GitOps/Helm tools for AI-assisted operations. |
+| [dbhq-uk/heliograph-skill](https://github.com/dbhq-uk/heliograph-skill) | prototype<br>approval<br>evidence<br>write | Community skill for diagnosing hosts the agent cannot reach: steps out and UTC-timestamped logs back over a private git repo, run by an on-site operator, for air-gapped and change-controlled estates. |
 
 ## How to contribute
 

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -18,6 +18,11 @@
       "category": "community-agent-skills"
     },
     {
+      "name": "dbhq-uk/heliograph-skill",
+      "url": "https://github.com/dbhq-uk/heliograph-skill",
+      "category": "community-agent-skills"
+    },
+    {
       "name": "google/skills",
       "url": "https://github.com/google/skills",
       "category": "official-agent-skills"

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1846,3 +1846,27 @@
     - mcp
     - approval
     - write
+
+- name: dbhq-uk/heliograph-skill
+  url: https://github.com/dbhq-uk/heliograph-skill
+  category: community-agent-skills
+  type: skill
+  framework: skills
+  primary_language: Shell
+  cloud_provider: multi-cloud
+  use_cases:
+    - air-gapped-diagnostics
+    - remote-incident-investigation
+    - operator-mediated-troubleshooting
+    - timestamped-evidence-capture
+  action_level: write-capable
+  human_approval: true
+  evidence_tracing: "yes"
+  maturity: prototype
+  risk_notes: "Steps are arbitrary shell run on the operator's control node, so scope the account that executes them and keep the transport repo private. Logs are committed and pushed, so anything a command prints is in git history permanently; built-in redaction masks common secret shapes and is a safety net, not a guarantee. The default loop is operator-run per step, but the optional unattended runner executes whatever is pushed to the branch it watches, so per-step human review only holds in the manual mode."
+  operator_note: "Diagnoses hosts the agent cannot reach at all - air-gapped, client-owned or change-controlled estates - by moving steps out and UTC-timestamped logs back over a private git repo. No tunnel, proxy or held-open connection; the only thing crossing the gap is a commit, run by someone who already has legitimate access. Every line is stamped, so a hang reads as a gap, and the log is pushed with its exit code even when the step fails."
+  labels:
+    - prototype
+    - approval
+    - evidence
+    - write


### PR DESCRIPTION
Adds `dbhq-uk/heliograph-skill` under Community Discovery and Skills.

**The operational use case.** Debugging a host the agent cannot reach at all: air-gapped, client-owned or change-controlled estates where only the customer's own staff can log in. It is not another investigator agent - it is the transport and capture layer for when SSH is off the table. Steps go out over a private git repo, an on-site operator runs one command that never changes (or starts an unattended runner), and the whole run comes back as a committed log. Every line carries a UTC timestamp, so a hang shows up as a gap rather than being indistinguishable from slow progress, and the log is pushed with its exit code even when the step fails.

**Classification, and why.**

| Field | Value | Reasoning |
| --- | --- | --- |
| `action_level` | `write-capable` | Steps are arbitrary shell. Nothing constrains them to reads, so the stricter label is the honest one |
| `human_approval` | `true` | The documented default is the operator pulling and running each step. Disclosed in `risk_notes`: the optional unattended runner executes whatever is pushed to the branch it watches, so per-step review only holds in the manual mode |
| `evidence_tracing` | `yes` | The committed log is the deliverable, not a side effect. Every run is retained in git, timestamped and untruncated |
| `maturity` | `prototype` | Published 11 Aug 2026. Stricter signal, per the contributing guide |

**Against the operator safety checklist.** No credentials of any kind: no cloud auth, no API keys, no tokens beyond the git remote. Nothing to give the agent, so it can be evaluated with no real cloud credentials at all - `bootstrap.sh` into a scratch repo and run `./run.sh env` against any box you already have. Blast radius is whatever account the operator runs it as, which is stated in `risk_notes`. Secrets handling is the one real caveat and it is documented in the skill's own `SECURITY.md` as well as here: logs are committed, so anything a command prints lands in git history permanently. `cap_redact` masks the common shapes on the way out and the README says plainly that this is a safety net, not a guarantee.

It does not tunnel, proxy or hold a connection open. The only thing that crosses the gap is a git commit, run by someone who already has legitimate access.

**Checklist**

- [x] Repo URL is public and reachable.
- [x] Specific category: `community-agent-skills`, an existing catalog slug.
- [x] `type: skill`, an existing validator-backed artifact kind.
- [x] `risk_notes` explains what could go wrong.
- [x] `operator_note` explains why an infrastructure operator should care.
- [x] Labels match observed behaviour: `prototype`, `approval`, `evidence`, `write`. No `prod`/`prototype` combination; `write` paired with `write-capable`; `evidence` paired with `evidence_tracing: yes`.
- [x] `data/repos.yaml` and `README.md` both updated, plus `data/catalog.json` and the README counts via `scripts/sync_catalog_json.py` and `scripts/sync_readme_counts.py`.
- [x] `python3 scripts/validate_repos_yaml.py` passes (81 entries); `pytest` passes (149 tests).
- [x] Open source, MIT. Nothing commercial-only, no paid tier, no gated functionality.

Disclosure: I am the author.
